### PR TITLE
wrap_text improvements

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -76,4 +76,4 @@ of each file for more information on full usage.
 
  * [wrap_text.py](wrap_text.py) is a simple plugin for reflowing multiline text
    so that it cuts off (hard wraps) at a predefined width, for example at a
-   ruler.
+   ruler. This can even be used with line comments!

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -1,6 +1,7 @@
 import sublime
 import sublime_plugin
 import textwrap
+from Default.comment import build_comment_data, ToggleCommentCommand
 
 # related reading: https://stackoverflow.com/a/46315431/4473405
 
@@ -17,35 +18,64 @@ class WrapTextCommand(sublime_plugin.TextCommand):
     If no width is specified, it will infer the desired width
     from the "rulers" setting on the view. If there are no rulers,
     a default of 72 is used.
+    
+    Known limitations:
+    - Wrapping contiguous text containing multiple indentation
+      levels will have terrible results.
+    - Wrapping line comments and anything else at the same time
+      will cause the entire selection to become line commented.
     """
     def run(self, edit, width=0):
-        new_sel = list()
         # use the narrowest ruler from the view if no width specified, or default to 72 if no rulers are enabled
         width = width or next(iter(self.view.settings().get('rulers', [])), 72)
         # determine the indentation style used in the view
         use_spaces = self.view.settings().get('translate_tabs_to_spaces', False)
         tab_size = self.view.settings().get('tab_size', 4)
         one_level = ' ' * tab_size if use_spaces else '\t'
+        
+        # make sure the entire line is selected for each selection region
+        # - `remove_line_comment` needs the region to be at the start of the line
+        # - `dedent` needs it in order to see what indentation all lines have in common
+        self.view.run_command('expand_selection', { 'to': 'line' })
+        
+        new_sel = list()
+        sel_comment_data = list()
+        
         # loop through the selections in reverse order so that the selection positions don't move when the selected text changes size
         for sel in reversed(self.view.sel()):
-            # make sure the leading indentation is selected, for `dedent` to work properly
-            sel = sel.cover(self.view.line(sel.begin()))
+            # if the selection contains any single line comments, toggle the comments off
+            # so the comment tokens won't get wrapped into the middle of the line - we'll reapply them later
+            comment_data = build_comment_data(self.view, sel.begin())
+            sel_comment_data.append(comment_data if ToggleCommentCommand.remove_line_comment(None, self.view, edit, comment_data, sel) else None)
+        
+        # loop through the selections in reverse order so that the selection positions don't move when the selected text changes size
+        for sel, comment_data in zip(reversed(self.view.sel()), sel_comment_data):
             # determine how much indentation is at the first selected line
             indentation_level = self.view.indentation_level(sel.begin())
             indentation = one_level * indentation_level
-            # create a wrapper that will keep that indentation
+            if comment_data: # if line comments were removed earlier
+                line_comments, block_comments = comment_data
+                # apply the line comment token as part of the indentation so the text wrapper will re-comment the text for us
+                if any(line_comments): # if there is at least one line comment token defined
+                    line_comment = line_comments[0] # if there are multiple such line comment tokens we will use the first one
+                    if line_comment[1]: # if the line comment token has DISABLE_INDENT set
+                        indentation = line_comment[0] + indentation # apply the indentation after the line comment token
+                    else:
+                        indentation += line_comment[0] # apply the indentation before the line comment token
+            
+            # create a text wrapper that will keep the existing indentation level
             wrapper = textwrap.TextWrapper(
                 drop_whitespace=True,
-                width=width - (0 if use_spaces else (tab_size - 1) * indentation_level), # if tabs are used, then we need to pretend the max width is smaller, because here Python counts a tab as a single char
+                width=width - (0 if use_spaces else (tab_size - 1) * indentation_level), # if hard tab characters are used, then we need to pretend the max width is smaller, because here Python counts a tab as a single char. Easier to just not use tabs, people!
                 initial_indent=indentation,
                 subsequent_indent=indentation,
                 expand_tabs=False,
                 replace_whitespace=True,
             )
-            # unindent the selected text before then reformatting the text to fill the available (column) space
+            # unindent the selected text, before then reformatting said text to fill the available (column) space
             text = wrapper.fill(textwrap.dedent(self.view.substr(sel)))
-            # replace the selected text with the rewrapped text
-            self.view.replace(edit, sel, text)
+            # replace the selected text with the re-wrapped text
+            self.view.replace(edit, sel, text + '\n')
             # resize the selection to match the new wrapped text size
             new_sel.append(sublime.Region(sel.begin(), sel.begin() + len(text)))
         self.view.sel().clear()

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -73,7 +73,13 @@ class WrapTextCommand(sublime_plugin.TextCommand):
                 replace_whitespace=True,
             )
             # unindent the selected text, before then reformatting said text to fill the available (column) space
-            text = wrapper.fill(textwrap.dedent(self.view.substr(sel)))
+            # do it on a paragraph by paragraph basis so we don't lose blank line gaps
+            text = ''
+            for paragraph in textwrap.dedent(self.view.substr(sel)).split('\n\n'):
+                if text != '':
+                    text += '\n\n'
+                text += wrapper.fill(paragraph)
+            
             # replace the selected text with the re-wrapped text
             self.view.replace(edit, sel, text + '\n')
             # resize the selection to match the new wrapped text size

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -21,7 +21,7 @@ class WrapTextCommand(sublime_plugin.TextCommand):
     def run(self, edit, width=0):
         new_sel = list()
         # use the narrowest ruler from the view if no width specified, or default to 72 if no rulers are enabled
-        width = width or self.view.settings().get('rulers', [72])[0]
+        width = width or next(iter(self.view.settings().get('rulers', [])), 72)
         # determine the indentation style used in the view
         use_spaces = self.view.settings().get('translate_tabs_to_spaces', False)
         tab_size = self.view.settings().get('tab_size', 4)


### PR DESCRIPTION
Here we have lots of improvements to the `wrap_text` functionality:

- it now supports when tab characters are used for indentation (eww!)
- it fixes a bug when the `rulers` setting on the view is an empty array (i.e. after removing previous rulers)
- it now supports wrapping line comments (see the commit text for details!)
- it keeps separate paragraphs... separate - rather than wrapping them together onto one long line