### PR TITLE
Include move_amount.py

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -45,7 +45,7 @@ of each file for more information on full usage.
 
  * [move_amount.py](move_amount.py) is a simple drop in replacement for the
    standard `move` command that allows you to specify the number of times the
-   movement happens. This can be handy for certain kinda of navigation or in
+   movement happens. This can be handy for certain kinds of navigation or in
    macros to make them more manageable if they contain a lot of motion.
 
  * [open_found_files.py](open_found_files.py) is an example of collecting all

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -43,6 +43,11 @@ of each file for more information on full usage.
    on a window-by-window basis (not view-by-view), so some chicanery is needed
    to pull this off.
 
+ * [move_amount.py](move_amount.py) is a simple drop in replacement for the
+   standard `move` command that allows you to specify the number of times the
+   movement happens. This can be handy for certain kinda of navigation or in
+   macros to make them more manageable if they contain a lot of motion.
+
  * [open_found_files.py](open_found_files.py) is an example of collecting all
    of the files that had a match as a part of a Find in Files operation and
    opening them all at once. Normally in order to do this you would have to

--- a/plugins/move_amount.py
+++ b/plugins/move_amount.py
@@ -1,0 +1,22 @@
+import sublime
+import sublime_plugin
+
+# Related reading:
+#     https://forum.sublimetext.com/t/command-to-move-by-several-lines/28508
+#     https://forum.sublimetext.com/t/command-to-move-by-several-lines/28508
+
+# A couple of users were interested in making the built in move command for
+# moving the cursor around be able to take the same action a number of times
+# instead of just once.
+
+# This creates a drop in replacement for the standard move command named
+# move_amount that takes the same arguments as move does, plus an extra argument
+# named amount for specifying how many times to take the action which defaults
+# to 1.
+
+# With this in place you can modify or duplicate existing motion key binds and
+# replace the command to get multiple motions easily.
+class MoveAmountCommand(sublime_plugin.TextCommand):
+    def run(self, edit, amount=1, **kwargs):
+        for _ in range(amount):
+            self.view.run_command("move", args=kwargs)

--- a/plugins/move_amount.py
+++ b/plugins/move_amount.py
@@ -3,7 +3,7 @@ import sublime_plugin
 
 # Related reading:
 #     https://forum.sublimetext.com/t/command-to-move-by-several-lines/28508
-#     https://forum.sublimetext.com/t/command-to-move-by-several-lines/28508
+#     https://stackoverflow.com/questions/46369685/sublime-how-can-i-jump-n-lines-with-the-keyboard-arrows/
 
 # A couple of users were interested in making the built in move command for
 # moving the cursor around be able to take the same action a number of times


### PR DESCRIPTION
Include the move_amount command that was originally written on the
Sublime forum and just recently cross posted to Stack Overflow. This
implements a drop in replacement for the move command that allows you
to specify how many times the action should happen.