### PR TITLE
Include indent_test plugin and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The layout of the files here is:
    than using the menu as not all of the options listed are in the command
    palette by default.
 
+ * [indent_test](indent_test/README.md) is a simple prototype plugin that
+   performs tests on the indent rules in Sublime in a manner similar to how
+   the internal syntax file testing works.
+
  * [plugins](plugins/README.md) is a bunch of one-off plugin samples that I
    have worked up in response to helping others (great excuse to learn the
    Sublime API) to stop them from getting lost in the mists of time, although

--- a/indent_test/Indent Tests.sublime-build
+++ b/indent_test/Indent Tests.sublime-build
@@ -1,0 +1,11 @@
+{
+    "target": "run_indent_tests",
+    "file_patterns": ["indentation_test*"],
+
+    "variants": [
+        {
+            "name": "All Indent Rules",
+            "find_all": true
+        }
+    ]
+}

--- a/indent_test/README.md
+++ b/indent_test/README.md
@@ -1,0 +1,76 @@
+Indent Tester
+-------------
+
+This is a prototype plugin for performing tests on the internal indentation
+rules that Sublime Text uses to automatically indent files as you type. This
+allows you to verify that newly added indent rules make the changes that you
+expected without having other effects.
+
+This is provided as a build system with a custom target and associated plugin
+command for performing the tests. The build system will be selected
+automatically if the current build is set to automatic and the file being built
+is an appropriate test file (see below). A variant in the build allows you to
+test all indent rules at once.
+
+In order to be recognized as an indent test file, all test files must have a
+filename that starts with `indentation_test` and be stored somewhere within the
+`Packages` folder. The remainder of the filename (and extension) can be
+whatever you like.
+
+Additionally, the first line of the file must contain a header similar to the
+following example, marking the file explicitly as an indentation test file and
+specifying the syntax of the contents of the file. The header may be preceded
+by any text desired (e.g. the comment characters for the language in question).
+
+An example might be the following file, named `indentation_test.c`:
+
+```c
+// INDENT TEST "Packages/C++/C.sublime-syntax"
+
+#include <stdio.h>
+
+int main(int argc, char const *argv[])
+{
+    int i= 0;
+
+    if (i == 0)
+        printf("I bet the %s complains about this\n",
+            "compiler");
+
+    return 0;
+}
+```
+
+### Usage
+
+The simplest way to use this would be to drop this entire folder into your
+Sublime Text `Packages` folder, where it will become a package.
+
+A new build system named `Indent Tests` is added to the `Tools > Build System`
+menu, with a main build action that tries to test based on the current file and
+a variant that will run all indent tests in all files.
+
+In the first case the appropriate build will be automatically selected as long
+as the build system is set to `Automatic` and you start the build from an
+appropriate file as outlined above.
+
+The build output displays the results of the tests. Any lines which fail the
+test (i.e. which do not get indented to the same level as in the input file)
+will be displayed in the build output, allowing you to quickly jump to the
+appropriate source line.
+
+### Caveats
+
+As a prototype plugin, please note the following:
+
+ * After a test, an output panel named `Output: Indent Test` is left behind,
+   which will contain the contents of the last tested file. If you're running
+   single tests, you can check the panel to see the final output.
+
+ * As a place holder for potential future enhancements, when you run a test on
+   a single file, all test files that use the same syntax are also tested as
+   well. This could be easily disabled if desired, but is really only of note
+   if you happen to have many indent tests for the same syntax.
+
+ * Probably issues not listed here because they haven't been noticed/reported
+   yet.

--- a/indent_test/run_indent_tests.py
+++ b/indent_test/run_indent_tests.py
@@ -1,0 +1,146 @@
+import os
+import re
+from difflib import ndiff
+
+import sublime
+import sublime_plugin
+
+# As evidenced here, the indent test code is based on code in this imported
+# module from the Default package.
+from Default.run_syntax_tests import package_relative_path, PACKAGES_FILE_REGEX
+from Default.run_syntax_tests import show_panel_on_build, append
+
+
+### ---------------------------------------------------------------------------
+
+
+class RunIndentTestsCommand(sublime_plugin.WindowCommand):
+    """
+    A custom command that can be executed from a build system target for
+    testing indent rules. The current file needs to have a known name prefix
+    to be considered, and must have a header line that tells the tester what
+    syntax it is.
+
+    The test inserts the data unindented into a view and then runs the reindent
+    command to indent it, comparing the results to what the input file looked
+    like to verify the indent level.
+    """
+    def run(self, find_all=False, **kwargs):
+        if not hasattr(self, 'output_view'):
+            # Try not to call get_output_panel until the regexes are assigned
+            self.output_view = self.window.create_output_panel('exec')
+
+        settings = self.output_view.settings()
+        settings.set('result_file_regex', PACKAGES_FILE_REGEX)
+        settings.set('result_base_dir', sublime.packages_path())
+        settings.set('word_wrap', True)
+        settings.set('line_numbers', False)
+        settings.set('gutter', False)
+        settings.set('scroll_past_end', False)
+
+        # Call create_output_panel a second time after assigning the above
+        # settings, so that it'll be picked up as a result buffer
+        self.window.create_output_panel('exec')
+
+        if find_all:
+            tests = sublime.find_resources('indentation_test*')
+        else:
+            # Can't test files that are not in the packages folder.
+            pkg_path = package_relative_path(self.window.active_view())
+            if not pkg_path:
+                return
+
+            # We can only test files that we know are indent tests.
+            file_name = os.path.basename(pkg_path)
+            if not file_name.startswith("indentation_test"):
+                return sublime.error_message(
+                    'The current file is not an indentation test')
+
+            # Get the syntax for the current file out of the header.
+            syntax = self.syntax_for_file(pkg_path)
+            if syntax is None:
+                return sublime.error_message(
+                    'The indentation test header is missing');
+
+            # At a minimum, we are going to test this file.
+            tests = [pkg_path]
+
+            # Find all other files that are using this syntax and add them to
+            # the test list. Realistically this should only happen if the
+            # current file was a tmPreferences file, but there is currently no
+            # good way to get the appropriate syntax from such a file.
+            for file in sublime.find_resources('indentation_test*'):
+                if file != pkg_path and self.syntax_for_file(file) == syntax:
+                    tests.append(file)
+
+        show_panel_on_build(self.window)
+
+        total_lines = 0
+        failed_lines = 0
+
+        for test in tests:
+            lines, failures = self.run_indent_test(test)
+            total_lines += lines
+            if len(failures) > 0:
+                failed_lines += len(failures)
+                for line in failures:
+                    append(self.output_view, line + '\n')
+
+        if failed_lines > 0:
+            message = 'FAILED: {} of {} lines in {} files failed\n'
+            params = (failed_lines, total_lines, len(tests))
+        else:
+            message = 'Success: {} lines in {} files passed\n'
+            params = (total_lines, len(tests))
+
+        append(self.output_view, message.format(*params))
+        append(self.output_view, '[Finished]')
+
+    def run_indent_test(self, package_file):
+        syntax = self.syntax_for_file(package_file)
+        if syntax is None:
+            return (0, [])
+
+        input_file = sublime.load_resource(package_file)
+        input_lines = input_file.splitlines()
+
+        view = self.window.create_output_panel("indent_test", False)
+
+        view.assign_syntax(syntax)
+        view.run_command("select_all")
+        view.run_command("left_delete")
+
+        for line in input_lines:
+            view.run_command("append", {"characters": line.lstrip() + "\n"})
+
+        view.run_command("select_all")
+        view.run_command("reindent")
+
+        output_file = view.substr(sublime.Region(0, view.size()))
+        output_lines = output_file.splitlines()
+
+        if input_file == output_file:
+            return (len(input_lines), [])
+
+        diff = ndiff(input_file.splitlines(), output_file.splitlines())
+
+        line_num = 0
+        errors = []
+        for line in diff:
+            prefix = line[:2]
+            line_num += 1 if prefix in ("  ", "+ ") else 0
+
+            if prefix == "+ ":
+                msg = "{}:{}:1: Indent Failure: {}".format(package_file, line_num, line[2:])
+                errors.append(msg)
+
+        # self.window.run_command("show_panel", {"panel": "output.indent_test"})
+        return (len(input_lines), errors)
+
+    def syntax_for_file(self, package_file):
+        first_line = sublime.load_resource(package_file).splitlines()[0]
+        match = re.match('^.*INDENT TEST "(.*?)"', first_line)
+        if not match:
+            return None
+
+        return match.group(1)


### PR DESCRIPTION
This includes a new prototype plugin for performing tests on indent
rules similar to how syntax testing works.

In use indent test files are created with a known name prefix and a
header line that marks the syntax that they use so that the
appropriate indent rules can be provided.

The provided build system will trigger automatically if a build is
invoked from within an indent test file, and also includes a variant
for running all indent tests all at once.

The test consists of inserting an unindented version of the test file
into a buffer, then running the indent command to indent the buffer,
which is then compared with the original to see if the indent worked
or not.