### PR TITLE
more wrap_text.py improvements

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -74,6 +74,10 @@ of each file for more information on full usage.
    sublime `toggle_setting` command that can toggle any setting between any
    value, instead of just toggling a boolean setting off and on.
 
- * [wrap_text.py](wrap_text.py) is a simple plugin for reflowing multiline text
-   so that it cuts off (hard wraps) at a predefined width, for example at a
-   ruler. This can even be used with line comments!
+ * [wrap_text.py](wrap_text.py) started as a simple plugin for reflowing
+   multiline text so that it cuts off (hard wraps) at a predefined width, for
+   example at a ruler. It was primarily designed for Python docstrings, but soon
+   became apparant that some more related functionality would make it super
+   useful - for example, wrapping line comments! - so it became quite a lot more
+   advanced. It now also makes it easier to join consecutive comment lines
+   together by pressing <kbd>delete</kbd> at the end of the first line.

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 import textwrap
-from Default.comment import build_comment_data, ToggleCommentCommand
+from Default.comment import build_comment_data, ToggleCommentCommand, advance_to_first_non_white_space_on_line
 
 # related reading: https://stackoverflow.com/a/46315431/4473405
 
@@ -86,3 +86,124 @@ class WrapTextCommand(sublime_plugin.TextCommand):
             new_sel.append(sublime.Region(sel.begin(), sel.begin() + len(text)))
         self.view.sel().clear()
         self.view.sel().add_all(new_sel)
+
+
+def find_region_matching_selector(view, within_region, selector):
+    is_match = lambda pt: view.match_selector(pos, selector)
+    pos = within_region.begin()
+    while pos < within_region.end() and not is_match(pos):
+        pos += 1
+    start_pos = pos
+    while pos < within_region.end() and is_match(pos):
+        pos += 1
+    return sublime.Region(start_pos, pos)
+
+
+class ContinueCommentOnNextLineCommand(sublime_plugin.TextCommand):
+    """
+    This is handy when you are in a comment, and want to spill over
+    into a new line manually. For a single line comment, this means
+    that the comment token would be inserted on the next line, for
+    a block comment, what one might want could depend on the syntax
+    and personal preference - for example, a space followed by an
+    asterisk, or nothing at all. (Here we will let the caller decide,
+    to keep things simple. Then the user can create a keybinding with
+    different arguments for different situations.)
+    
+    We can't rely on the meta info for the syntax to tell us what the
+    line comment token is (as at Build 3144, the C# syntax definition
+    scopes `///` as a documentation block comment, but it is really a
+    line comment, and it is not included in the meta info), so we
+    instead find the punctuation scope at the beginning of the line to
+    find the line comment token.
+    """
+    def run(self, edit, insert_what=None):
+        if insert_what is None:
+            # find text with the `punctuation` scope on the line, only searching up to the caret position
+            pos = self.view.sel()[0].begin()
+            line_begin = self.view.line(pos).begin()
+            region = find_region_matching_selector(self.view, sublime.Region(line_begin, pos), 'punctuation')
+            insert_what = self.view.substr(region)
+        # the insert command will take care of keeping the indentation after the \n the same as the current line
+        if insert_what:
+            insert_what += ' ' # don't insert a space when pressing `enter` before the start of a line comment
+        self.view.run_command('insert', { 'characters': '\n' + insert_what })
+
+
+def unique_regions(regions):
+    # NOTE: using `set(` directly doesn't work due to Region not being a hashable type...
+    return set(map(lambda region: (region.begin(), region.end()), regions))
+
+
+class JoinLineBelowCommand(sublime_plugin.TextCommand):
+    """
+    Join the line below to the current line - no matter where the caret
+    is. This will remove the `\n` character at EOL, and all leading
+    whitespace at the beginning of the next line (i.e. indentation).
+    
+    Also, if the `\n` on the current line is scoped as a comment line,
+    then look for more comment line punctuation on the beginning of the
+    next line, and remove that too. This makes it easy to join comment
+    lines together. If a space precedes the end of the current line,
+    also remove leading whitespace after the comment token.
+    """
+    def run(self, edit):
+        # get a unique list of lines where the caret(s) are
+        caret_lines = unique_regions([self.view.line(sel) for sel in self.view.sel()])
+        # iterate through them in reverse order, so that the selection positions don't move when the gaps between the text change size
+        for current_line_begin, current_line_end in reversed(list(caret_lines)):
+            next_line = self.view.line(current_line_end + 1)
+            # find where the leading whitespace on the next line ends
+            whitespace_ends = min(next_line.end(), advance_to_first_non_white_space_on_line(self.view, next_line.begin()))
+            # if the current line is a comment
+            if self.view.match_selector(current_line_end, 'comment'):
+                # find where the comment punctuation ends
+                if self.view.match_selector(whitespace_ends, 'punctuation.definition.comment - punctuation.definition.comment.end'):
+                    whitespace_ends = find_region_matching_selector(self.view, sublime.Region(whitespace_ends, next_line.end()), 'punctuation').end()
+                    # if a space preceeds the end of the current line
+                    if self.view.substr(max(current_line_begin, current_line_end - 1)) == ' ':
+                        # also remove leading whitespace after the comment token
+                        whitespace_ends = min(next_line.end(), advance_to_first_non_white_space_on_line(self.view, whitespace_ends))
+            # remove the \n and any leading whitespace on the next line
+            self.view.replace(edit, sublime.Region(current_line_end, whitespace_ends), '')
+
+# Example keybindings (duplicate `enter` to `keypad_enter` if desired)
+# { "keys": ["alt+q"], "command": "wrap_text" },
+# { "keys": ["enter"], "command": "continue_comment_on_next_line",
+#     "args": {
+#         "insert_what": "*",
+#     },
+#     "context": [
+#         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation", "match_all": true },
+#         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+#         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "/\\*", "match_all": true },
+#     ],
+# },
+# { "keys": ["enter"], "command": "continue_comment_on_next_line",
+#     "args": {
+#         "insert_what": " *",
+#     },
+#     "context": [
+#         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation", "match_all": true },
+#         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+#         { "key": "preceding_text", "operator": "regex_contains", "operand": "/\\*", "match_all": true },
+#     ],
+# },
+# { "keys": ["enter"], "command": "continue_comment_on_next_line",
+#     "context": [
+#         { "key": "selector", "operator": "equal", "operand": "comment.block.documentation.cs", "match_all": true },
+#         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+#     ],
+# },
+# { "keys": ["enter"], "command": "continue_comment_on_next_line",
+#     "context": [
+#         { "key": "selector", "operator": "equal", "operand": "comment.line", "match_all": true },
+#         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+#     ],
+# },
+# { "keys": ["delete"], "command": "join_line_below",
+#     "context": [
+#         { "key": "following_text", "operator": "regex_match", "operand": "$", "match_all": true },
+#         { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+#     ],
+# },

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -124,7 +124,7 @@ class ContinueCommentOnNextLineCommand(sublime_plugin.TextCommand):
             # find text with the `punctuation` scope on the line, only searching up to the caret position
             pos = self.view.sel()[0].begin()
             line_begin = self.view.line(pos).begin()
-            region = find_region_matching_selector(self.view, sublime.Region(line_begin, pos), 'punctuation')
+            region = find_region_matching_selector(self.view, sublime.Region(line_begin, pos), 'comment punctuation')
             insert_what = self.view.substr(region)
         # the insert command will take care of keeping the indentation after the \n the same as the current line
         if insert_what:
@@ -164,7 +164,7 @@ class JoinLineBelowCommand(sublime_plugin.TextCommand):
             if self.view.match_selector(current_line_end, 'comment'):
                 # find where the comment punctuation ends
                 if self.view.match_selector(whitespace_ends, 'punctuation.definition.comment - punctuation.definition.comment.end'):
-                    whitespace_ends = find_region_matching_selector(self.view, sublime.Region(whitespace_ends, next_line.end()), 'punctuation').end()
+                    whitespace_ends = find_region_matching_selector(self.view, sublime.Region(whitespace_ends, next_line.end()), 'comment punctuation').end()
                     # also remove leading whitespace after the comment token
                     whitespace_ends = min(next_line.end(), advance_to_first_non_white_space_on_line(self.view, whitespace_ends))
             # if a space preceeds the end of the current line, don't insert a space before the line being joined, otherwise do

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -168,7 +168,7 @@ class JoinLineBelowCommand(sublime_plugin.TextCommand):
                     # also remove leading whitespace after the comment token
                     whitespace_ends = min(next_line.end(), advance_to_first_non_white_space_on_line(self.view, whitespace_ends))
             # if a space preceeds the end of the current line, don't insert a space before the line being joined, otherwise do
-            replace_with = '' if self.view.substr(max(current_line_begin, current_line_end - 1)) == ' ' else ' '
+            replace_with = '' if self.view.substr(max(current_line_begin, current_line_end - 1)) == ' ' or next_line.empty() else ' '
             # remove the \n and any leading whitespace on the next line
             self.view.replace(edit, sublime.Region(current_line_end, whitespace_ends), replace_with)
 

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -172,6 +172,15 @@ class JoinLineBelowCommand(sublime_plugin.TextCommand):
             # remove the \n and any leading whitespace on the next line
             self.view.replace(edit, sublime.Region(current_line_end, whitespace_ends), replace_with)
 
+
+#  capture when the built in wrap_lines command is executed and rewrite it to execute our much better command instead
+class WrapTextListener(sublime_plugin.EventListener):
+    def on_text_command(self, view, command_name, args):
+        if command_name == 'wrap_lines':
+            return ('wrap_text', args)
+        return None
+
+
 # Example keybindings (duplicate `enter` to `keypad_enter` if desired)
 # { "keys": ["alt+q"], "command": "wrap_text" },
 # { "keys": ["enter"], "command": "continue_comment_on_next_line",


### PR DESCRIPTION
This PR adds numerous additional improvements to the `wrap_text.py` plugin. Notably:

- easily join consecutive line comments together by pressing <kbd>Del</kbd> at the end of the first line - this will get rid of whitespace (indentation) and the line comment punctuation. (This functionality can be used not only for line comments, but this is where it really shines!)
- use our `wrap_text` command in place of the default `wrap_lines`, which is useless/harmful when the lines contain indentation
- automatically deselect trailing newlines from all selections before wrapping the text, to avoid surprising situations where lines that weren't selected were being wrapped