### PR TITLE
Use new command palette input for scratch syntax

### DIFF
--- a/scratch_files/Default.sublime-commands
+++ b/scratch_files/Default.sublime-commands
@@ -11,5 +11,9 @@
     { "caption": "Scratch Buffer: JSON",              "command": "scratch_buffer", "args": {"syntax": "Packages/JavaScript/JSON.sublime-syntax"}},
     { "caption": "Scratch Buffer: Python",            "command": "scratch_buffer", "args": {"syntax": "Packages/Python/Python.sublime-syntax"}},
     { "caption": "Scratch Buffer: TypeScript",        "command": "scratch_buffer", "args": {"syntax": "Packages/TypeScript/TypeScript.tmLanguage"}},
-    { "caption": "Scratch Buffer: Prompt for Syntax", "command": "scratch_buffer", "args": {"syntax": null}}
+
+    // For versions of Sublime prior to build 3154, swap these around. Input in
+    // the command palette looks nicer with a shorter command name.
+    // { "caption": "Scratch Buffer: Prompt for Syntax", "command": "scratch_buffer", "args": {"syntax": null}}
+    { "caption": "Scratch Buffer",                    "command": "scratch_buffer", "args": {"syntax": null}}
 ]

--- a/scratch_files/README.md
+++ b/scratch_files/README.md
@@ -36,6 +36,13 @@ The default value for this argument if you do not provide it is
 `None` for this argument, which will cause the command to prompt you for the
 syntax to use first.
 
+If you're using build 3154 or later of Sublime Text and invoke the the
+`scratch_buffer` command from the command palette with this argument set to
+`None`, the selection of the syntax will happen directly in the command
+palette.
+
+In all other cases the syntax selection is done via a quick panel instead.
+
 The folder also contains a `sublime-commands` file which adds a variety of
 languages to the command palette. You can use this as is, merge it with your
 own, add often used syntaxes, etc.


### PR DESCRIPTION
This enhances the scratch buffer sample plugin so that when invoked
with a syntax of None from the command palette, the selection of the
syntax is done using the new command palette input mechanism.

The previous handling for this situation (prompting for the syntax in
a quick panel) is still done whenever the command is executed with a
syntax of None in all other cases, since the new handling only works
from within the command palette itself.

The plugin code adapts to this situation by using the input handler as
a simple proxy to get the appropriate information for the quick panel
to avoid code duplication.

Additionally, guard code is in place so that when the plugin is loaded
by versions of Sublime prior to build 3154 (where the command input
was first added) things gracefully fall back as expected.