### PR TITLE
Some slight cleanup in the scratch files plugin

### DIFF
--- a/scratch_files/Default.sublime-commands
+++ b/scratch_files/Default.sublime-commands
@@ -1,19 +1,12 @@
 [
-    // The list of scratch buffers I often use.
-    //
-    // Note that the option for TypeScript requires a TypeScript plugin to be
-    // installed; as of build 3126, Sublime doesn't ship with support for this
-    // language.
-    { "caption": "Scratch Buffer: Plain Text",        "command": "scratch_buffer"},
+    // Examples of commonly used syntaxes for scratch buffers.
+    { "caption": "Scratch Buffer: Plain Text",        "command": "scratch_buffer", "args": {"syntax": "Packages/Text/Plain text.tmLanguage"}},
     { "caption": "Scratch Buffer: Markdown",          "command": "scratch_buffer", "args": {"syntax": "Packages/Markdown/Markdown.sublime-syntax"}},
     { "caption": "Scratch Buffer: HTML",              "command": "scratch_buffer", "args": {"syntax": "Packages/HTML/HTML.sublime-syntax"}},
     { "caption": "Scratch Buffer: JavaScript",        "command": "scratch_buffer", "args": {"syntax": "Packages/JavaScript/JavaScript.sublime-syntax"}},
     { "caption": "Scratch Buffer: JSON",              "command": "scratch_buffer", "args": {"syntax": "Packages/JavaScript/JSON.sublime-syntax"}},
     { "caption": "Scratch Buffer: Python",            "command": "scratch_buffer", "args": {"syntax": "Packages/Python/Python.sublime-syntax"}},
-    { "caption": "Scratch Buffer: TypeScript",        "command": "scratch_buffer", "args": {"syntax": "Packages/TypeScript/TypeScript.tmLanguage"}},
 
-    // For versions of Sublime prior to build 3154, swap these around. Input in
-    // the command palette looks nicer with a shorter command name.
-    // { "caption": "Scratch Buffer: Prompt for Syntax", "command": "scratch_buffer", "args": {"syntax": null}}
-    { "caption": "Scratch Buffer",                    "command": "scratch_buffer", "args": {"syntax": null}}
+    // When no syntax is provided, you are prompted for the syntax to use.
+    { "caption": "Scratch Buffer: Prompt for Syntax", "command": "scratch_buffer" }
 ]

--- a/scratch_files/README.md
+++ b/scratch_files/README.md
@@ -1,25 +1,21 @@
 Scratch Files
 -------------
 
-I've been using Sublime Text for less than a year and it's already become an
-indispensable tool for my every day use. Not only do I use it for all of my
-code and text editing, I also use it for temporary scratch pads when I'm
-working on stuff.
-
 Often, when helping people out with problems they might be having it is
 required to come up with a code sample or simply play around with sample text.
 Although it is simple to create a new view and set the syntax using a keystroke
 and the command palette, that leaves you with a file that you get asked to save
 when you probably don't care.
 
-This simple blob of code adds some commands to the command palette that create
-a view, set the appropriate syntax and mark it as a scratch buffer so that it
-can be closed with impunity. An event listener catches attempts to try and save
-the file and turns off the scratch setting on save so that the buffer is just
-an ordinary one again.
+This simple blob of code adds a command that creates a view, sets the
+appropriate syntax and marks it as a scratch buffer so that it can be closed
+with impunity.
 
-Although this is simple and probably useful to only me, I hold this as a great
-example of how easy it is to improve your work flow in Sublime Text.
+An event listener catches a save on the scratch buffer and turns off the
+scratch setting so that the buffer becomes an ordinary file buffer again,
+stopping you from losing any work if you decide your scratch file should be
+more permanent.
+
 
 ### Usage
 
@@ -31,21 +27,19 @@ put it directly into some package (e.g. your `User` package) and use it that
 way. It adds a command called `scratch_buffer` that takes an argument of
 `syntax`, which should point to the name of a syntax that you want.
 
-The default value for this argument if you do not provide it is
-`"Packages/Text/Plain text.tmLanguage"`. It is also possible to explicitly pass
-`None` for this argument, which will cause the command to prompt you for the
-syntax to use first.
+If no `syntax` argument is given, you will be prompted to select the
+appropriate syntax from a quick panel containing of all syntaxes that Sublime
+currently knows about before the buffer is created.
 
-If you're using build 3154 or later of Sublime Text and invoke the the
-`scratch_buffer` command from the command palette with this argument set to
-`None`, the selection of the syntax will happen directly in the command
-palette.
-
-In all other cases the syntax selection is done via a quick panel instead.
+If you're using build 3154 or later of Sublime Text and invoke the
+`scratch_buffer` command from the command palette with without specifying a
+value for the `syntax` arg, the selection of the syntax will happen directly in
+the command palette instead of a quick panel.
 
 The folder also contains a `sublime-commands` file which adds a variety of
 languages to the command palette. You can use this as is, merge it with your
 own, add often used syntaxes, etc.
 
-It is also possible to map this command to a key press, if you have a particular
-syntax that you use often for example.
+Additional uses of this could might be to add a menu item to create scratch
+files or even bind the command to a key press if you happen to often create a
+scratch file of a certain type.

--- a/scratch_files/scratch_buffer.py
+++ b/scratch_files/scratch_buffer.py
@@ -42,23 +42,23 @@ class ScratchBufferCommand(sublime_plugin.WindowCommand):
     Create a scratch view with the provided syntax already set. If syntax is
     None, you get prompted to select a syntax first.
     """
-    def run(self, syntax="Packages/Text/Plain text.tmLanguage"):
+    def run(self, syntax=None):
         if syntax is None:
-            self.query_syntax()
-        else:
-            self.new_view(syntax)
+            return self.query_syntax()
 
-    def input(self, args):
-        if args.get("syntax", None) is None:
-            return SyntaxListInputHandler()
-
-    def new_view(self, syntax):
         view = self.window.new_file()
         view.set_name("Scratch: %s" % _syntax_name(syntax))
 
         view.set_scratch(True)
         view.assign_syntax(syntax)
         view.settings().set("is_temp_scratch", True)
+
+    def input(self, args):
+        if args.get("syntax", None) is None:
+            return SyntaxListInputHandler()
+
+    def input_description(self):
+        return "Scratch Buffer"
 
     def query_syntax(self):
         items = [list(val) for val in SyntaxListInputHandler().list_items()]


### PR DESCRIPTION
This is a bit of README and code cleanup in the scratch files plugin,
along with a change to the way the command palette input works to take
advantage of changes made to this new input method after the initial
dev build that introduced it.

When the feature was initially added, the name of the command from the
command palette entry was used as the initial text in the command
palette. A subsequent release added the new `input_description` method
on command, which is queried to provide the text that's displayed in
lieu of the command palette entry.

As a consequence, initially the command palette did not tell you that
the scratch buffer command was going to prompt you for a syntax so
that it would look cleaner when you ran the command. Now it tells you
that it is going to prompt you, and the command tells you what you
should be entering instead, which looks cleaner.

As a part of the cleanup, the default is now to prompt you for a
syntax when you don't explicitly set one, rather than the previous
default of assuming plain text.