### PR TITLE
update scratch_files plugin to read syntax name from the YAML

### DIFF
--- a/scratch_files/scratch_buffer.py
+++ b/scratch_files/scratch_buffer.py
@@ -9,16 +9,16 @@ HandlerBase = sublime_plugin.ListInputHandler if st_ver >= 3154 else object
 
 
 def _syntax_name(syntax_res):
-    syntax_file = os.path.basename(os.path.split(syntax_res)[1])
+    syntax_file = os.path.basename(syntax_res)
     name, ext = os.path.splitext(syntax_file)
-    
+
     if ext == '.sublime-syntax':
         contents = sublime.load_resource(syntax_res)
         # read the name from the YAML - not worth having a dependency on a full YAML parser for this...
         match = re.search(r'^name:\s+([^\r\n]+|\'[^\']+\')$', contents, re.MULTILINE)
         if match:
             name = match.group(1)
-    
+
     return name
 
 
@@ -36,6 +36,11 @@ class SyntaxListInputHandler(HandlerBase):
     def parse(self, langs, resource_spec):
         for syntax in sublime.find_resources(resource_spec):
             langs[_syntax_name(syntax)] = syntax
+
+    def preview(self, value):
+        return sublime.Html("<strong>{}</strong>: <em>{}</em>".format(
+            value.split("/")[1],
+            os.path.basename(value)))
 
     def list_items(self):
         langs = {}
@@ -56,7 +61,7 @@ class ScratchBufferCommand(sublime_plugin.WindowCommand):
             return self.query_syntax()
 
         view = self.window.new_file()
-        view.set_name("Scratch: %s" % _syntax_name(syntax))
+        view.set_name("Scratch: {}".format(_syntax_name(syntax)))
 
         view.set_scratch(True)
         view.assign_syntax(syntax)


### PR DESCRIPTION
This is a small tweak to improve the way the syntaxes are displayed in the scratch buffer prompt. Previously, it was just using the base name of the file, but in some cases, the base name and the name used by Sublime don't match, and it was confusing trying to find some syntaxes in the list.
This was especially noticeable for files with lowercase names, as of course the items are sorted lexographically, making such syntaxes appear under the rest, seemingly "out of order".
Whereas the "name" defined in the syntax definition itself is generally a more uniform, Title Case form.
To avoid requiring a YAML parser as a dependency, as there isn't one bundled with ST/ST's Python by default, it just uses a simple regex lookup.
This should probably also be updated in future to read the name of `.tmLanguage` files too... Then, the syntax selected in the prompt will always match what ST will display as the current syntax.