### PR TITLE
Docstring wrap

### DIFF
--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -148,7 +148,10 @@ class JoinLineBelowCommand(sublime_plugin.TextCommand):
     whitespace at the beginning of the next line (i.e. indentation).
     
     If a space doesn't preceed the end of the current line, add a space
-    before joining the lines together.
+    before joining the lines together, if the next line isn't empty and
+    doesn't consist only of whitespace (as that will get trimmed and we
+    would end up with a space after the caret and nothing after it when
+    using this command to remove "blank" lines below the current one).
     
     Also, if the `\n` on the current line is scoped as a comment line,
     then look for more comment line punctuation on the beginning of the
@@ -170,8 +173,8 @@ class JoinLineBelowCommand(sublime_plugin.TextCommand):
                     whitespace_ends = find_region_matching_selector(self.view, sublime.Region(whitespace_ends, next_line.end()), 'comment punctuation').end()
                     # also remove leading whitespace after the comment token
                     whitespace_ends = min(next_line.end(), advance_to_first_non_white_space_on_line(self.view, whitespace_ends))
-            # if a space preceeds the end of the current line, don't insert a space before the line being joined, otherwise do
-            replace_with = '' if self.view.substr(max(current_line_begin, current_line_end - 1)) == ' ' or next_line.empty() else ' '
+            # if a space preceeds the end of the current line, or the current or next line is empty, don't insert a space before the line being joined, otherwise do
+            replace_with = '' if self.view.substr(max(current_line_begin, current_line_end - 1)) in (' ', '\n') or next_line.empty() or whitespace_ends == next_line.end() else ' '
             # remove the \n and any leading whitespace on the next line
             self.view.replace(edit, sublime.Region(current_line_end, whitespace_ends), replace_with)
 

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -241,7 +241,7 @@ class DeselectTrailingNewlines(sublime_plugin.TextCommand):
 #     "context": [
 #         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation - (text - text source)", "match_all": true },
 #         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
-#         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "/\\*", "match_all": true },
+#         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "/\\*|\\*/$|^$", "match_all": true },
 #     ],
 # },
 # { "keys": ["enter"], "command": "continue_comment_on_next_line", // when on a block comment line without an asterisk on it already - i.e. the opening /* line, we need to insert a space and an asterisk when the user presses <kbd>Enter</kbd>
@@ -252,18 +252,14 @@ class DeselectTrailingNewlines(sublime_plugin.TextCommand):
 #         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation - (text - text source)", "match_all": true }, // don't trigger for XML, HTML (/ Markdown) or other syntaxes unless in an embedded source scope inside Markdown for example
 #         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
 #         { "key": "preceding_text", "operator": "regex_contains", "operand": "/\\*", "match_all": true },
+#         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*/$|^$", "match_all": true },
 #     ],
 # },
 # { "keys": ["enter"], "command": "continue_comment_on_next_line",
 #     "context": [
-#         { "key": "selector", "operator": "equal", "operand": "comment.block.documentation.cs", "match_all": true },
+#         { "key": "selector", "operator": "equal", "operand": "comment.line, comment.block.documentation.cs", "match_all": true },
 #         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
-#     ],
-# },
-# { "keys": ["enter"], "command": "continue_comment_on_next_line",
-#     "context": [
-#         { "key": "selector", "operator": "equal", "operand": "comment.line", "match_all": true },
-#         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+#         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "^$", "match_all": true },
 #     ],
 # },
 # { "keys": ["delete"], "command": "join_line_below",

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -39,7 +39,10 @@ class WrapTextCommand(sublime_plugin.TextCommand):
         # but first, ensure we follow the Principal of Least Surprise by not expanding the selection to lines where only column 0 is selected
         # - related reading: https://forum.sublimetext.com/t/next-line-is-included-when-sorting-a-multi-line-selection/30580
         self.view.run_command('deselect_trailing_newlines')
-        self.view.run_command('expand_selection', { 'to': 'line' })
+        if any(sel for sel in self.view.sel() if not sel.empty()):
+            self.view.run_command('expand_selection', { 'to': 'line' })
+        else:
+            self.view.run_command('expand_selection_to_paragraph')
         
         new_sel = list()
         sel_comment_data = list()

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -249,6 +249,7 @@ class DeselectTrailingNewlines(sublime_plugin.TextCommand):
 # { "keys": ["delete"], "command": "join_line_below",
 #     "context": [
 #         { "key": "following_text", "operator": "regex_match", "operand": "$", "match_all": true },
+#         { "key": "preceding_text", "operator": "not_regex_match", "operand": "^", "match_all": true },
 #         { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 #         //{ "key": "selector", "operator": "equal", "operand": "comment", "match_all": true },
 #     ],

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -231,22 +231,22 @@ class DeselectTrailingNewlines(sublime_plugin.TextCommand):
 
 # Example keybindings (duplicate `enter` to `keypad_enter` if desired)
 # { "keys": ["alt+q"], "command": "wrap_text" },
-# { "keys": ["enter"], "command": "continue_comment_on_next_line",
+# { "keys": ["enter"], "command": "continue_comment_on_next_line", // when on a block comment line with an asterisk on it already, ST will keep the space before it when pressing <kbd>Enter</kbd>, so we just need to insert another asterisk
 #     "args": {
 #         "insert_what": "*",
 #     },
 #     "context": [
-#         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation - comment.block.html - comment.block.xml", "match_all": true },
+#         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation - (text - text source)", "match_all": true },
 #         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
 #         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "/\\*", "match_all": true },
 #     ],
 # },
-# { "keys": ["enter"], "command": "continue_comment_on_next_line",
+# { "keys": ["enter"], "command": "continue_comment_on_next_line", // when on a block comment line without an asterisk on it already - i.e. the opening /* line, we need to insert a space and an asterisk when the user presses <kbd>Enter</kbd>
 #     "args": {
 #         "insert_what": " *",
 #     },
 #     "context": [
-#         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation - comment.block.html - comment.block.xml", "match_all": true },
+#         { "key": "selector", "operator": "equal", "operand": "comment.block - comment.block.documentation - (text - text source)", "match_all": true }, // don't trigger for XML, HTML (/ Markdown) or other syntaxes unless in an embedded source scope inside Markdown for example
 #         { "key": "auto_complete_visible", "operator": "equal", "operand": false },
 #         { "key": "preceding_text", "operator": "regex_contains", "operand": "/\\*", "match_all": true },
 #     ],

--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 import textwrap
-from Default.comment import build_comment_data, ToggleCommentCommand, advance_to_first_non_white_space_on_line
+from Default.comment import advance_to_first_non_white_space_on_line, build_comment_data
 
 # related reading: https://stackoverflow.com/a/46315431/4473405
 
@@ -48,23 +48,30 @@ class WrapTextCommand(sublime_plugin.TextCommand):
         for sel in reversed(self.view.sel()):
             # if the selection contains any single line comments, toggle the comments off
             # so the comment tokens won't get wrapped into the middle of the line - we'll reapply them later
-            comment_data = build_comment_data(self.view, sel.begin())
-            sel_comment_data.append(comment_data if ToggleCommentCommand.remove_line_comment(None, self.view, edit, comment_data, sel) else None)
+            # note the selector doesn't just use `comment.line punctuation.definition.comment`, because C# line documentation comments are scoped as `comment.block.documentation.cs punctuation.definition.comment.documentation.cs`
+            comment_punctuation = list(find_regions_matching_selector(self.view, sel, 'comment punctuation.definition.comment - punctuation.definition.comment.begin - punctuation.definition.comment.end'))
+            sel_comment_data.append(self.view.substr(comment_punctuation[0]) + ' ' if any(comment_punctuation) else None)
+            for punctuation in reversed(comment_punctuation):
+                # also remove any space after the comment line punctuation, else the `indentation_level` API can return the wrong result...
+                if self.view.substr(punctuation.end()) == ' ':
+                    punctuation = punctuation.cover(sublime.Region(punctuation.end(), punctuation.end() + len(' ')))
+                self.view.erase(edit, punctuation)
         
         # loop through the selections in reverse order so that the selection positions don't move when the selected text changes size
-        for sel, comment_data in zip(reversed(self.view.sel()), sel_comment_data):
+        for sel, line_comment in zip(reversed(self.view.sel()), sel_comment_data):
             # determine how much indentation is at the first selected line
             indentation_level = self.view.indentation_level(sel.begin())
             indentation = one_level * indentation_level
-            if comment_data: # if line comments were removed earlier
-                line_comments, block_comments = comment_data
+            
+            if line_comment: # if line comments were removed earlier
+                comment_data = build_comment_data(self.view, sel.begin())
+                # find the line comment that corresponds to the comment punctuation used, and check if indentation is disabled for it or not
+                disable_indent = next((data[1] for data in comment_data if isinstance(data, tuple) and data[0].strip() == line_comment), False)
                 # apply the line comment token as part of the indentation so the text wrapper will re-comment the text for us
-                if any(line_comments): # if there is at least one line comment token defined
-                    line_comment = line_comments[0] # if there are multiple such line comment tokens we will use the first one
-                    if line_comment[1]: # if the line comment token has DISABLE_INDENT set
-                        indentation = line_comment[0] + indentation # apply the indentation after the line comment token
-                    else:
-                        indentation += line_comment[0] # apply the indentation before the line comment token
+                if disable_indent: # if the line comment token has DISABLE_INDENT set
+                    indentation = line_comment + indentation # apply the indentation after the line comment token
+                else:
+                    indentation += line_comment # apply the indentation before the line comment token
             
             # create a text wrapper that will keep the existing indentation level
             wrapper = textwrap.TextWrapper(
@@ -101,8 +108,18 @@ def find_region_matching_selector(view, within_region, selector):
     # advance while the selector matches to find the extent the scope
     while pos < within_region.end() and is_match(pos):
         pos += 1
+    if start_pos == pos:
+        return None
     return sublime.Region(start_pos, pos)
 
+def find_regions_matching_selector(view, within_region, selector):
+    while True:
+        region = find_region_matching_selector(view, within_region, selector)
+        if region:
+            yield region
+            within_region = sublime.Region(region.end(), within_region.end())
+        else:
+            return
 
 class ContinueCommentOnNextLineCommand(sublime_plugin.TextCommand):
     """


### PR DESCRIPTION
Some fixes to the comment wrapping code. This bundles all of the changes that you made and probably know more about than I do, plus a change to the example key bindings in the plugin file.

They better restrict themselves to not extend comments when they should not; generally as a consequence of the scope of the caret position including the comment scope when it's in the character position immediately after the last comment character, which makes the plugin throw an exception for line comments.

The same issue also would make a block comment extend even if the line the cursor is on just closed it, which is now fixed as well.