### PR TITLE
Fix scratch_buffer quick panel fallback selection

### DIFF
--- a/scratch_files/scratch_buffer.py
+++ b/scratch_files/scratch_buffer.py
@@ -79,7 +79,7 @@ class ScratchBufferCommand(sublime_plugin.WindowCommand):
 
         def pick(idx):
             if idx != -1:
-                self.new_view(items[idx][1])
+                self.run(syntax=items[idx][1])
 
         self.window.show_quick_panel(
             items,


### PR DESCRIPTION
The existing `scratch_buffer` command is broken in that when you are
prompted for a syntax via a quick panel, although you can select a
syntax, it throws an error instead of actually creating a view in
response.
    
The reason for this is that the code assumes a method on the command
class that does not exist. This method was factored out in f1e8bb4 when
the code for it was inlined in the `run` method without also fixing
the call point.
