### PR TITLE
Allow wrap_text to leave the selection at the end of the wrapped text

### DIFF
--- a/plugins/wrap_text.py
+++ b/plugins/wrap_text.py
@@ -25,7 +25,7 @@ class WrapTextCommand(sublime_plugin.TextCommand):
     - Wrapping line comments and anything else at the same time
       will cause the entire selection to become line commented.
     """
-    def run(self, edit, width=0):
+    def run(self, edit, width=0, keep_selection=False):
         # use the narrowest ruler from the view if no width specified, or default to 72 if no rulers are enabled
         width = width or next(iter(self.view.settings().get('rulers', [])), 72)
         # determine the indentation style used in the view
@@ -95,8 +95,10 @@ class WrapTextCommand(sublime_plugin.TextCommand):
             
             # replace the selected text with the re-wrapped text
             self.view.replace(edit, sel, text + '\n')
-            # resize the selection to match the new wrapped text size
-            new_sel.append(sublime.Region(sel.begin(), sel.begin() + len(text)))
+            # resize the selection to match the new wrapped text size - or move it to the end of the wrapped text
+            end_pos = sel.begin() + len(text)
+            start_pos = sel.begin() if keep_selection else end_pos
+            new_sel.append(sublime.Region(start_pos, end_pos))
         self.view.sel().clear()
         self.view.sel().add_all(new_sel)
 


### PR DESCRIPTION
This change allows the `wrap_text` command to leave the selection at the end of the wrapped text which is more consistent with the `wrap_lines` behavior that it replaces/enhances, and so it does this by default now.
I've kept the old behavior available from keybindings etc. by adding a `keep_selection` argument to the command. This way, if people want to be able to visually see what got wrapped (for example, when starting with no selection) then they still can. I feel this is better than adding a preference because maybe users will want two different keybindings/behaviors for different circumstances.