### PR TITLE
Include session cleaning script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ The layout of the files here is:
    how a `sublime-build` file is used. This allows for things like custom
    variables in command lines and selecting the command to build at runtime
    instead of hard coding it.
+
+ * [session_cleaner](session_cleaner/README.md) is a Python script that cleans
+   the recent worksapces section of the `Session.sublime_session` file so that
+   projects that no longer exist don't show up in the project switch panel.

--- a/session_cleaner/README.md
+++ b/session_cleaner/README.md
@@ -1,0 +1,65 @@
+Sublime Session Cleaner
+-----------------------
+
+As you work with Projects in Sublime, the list of projects that you've worked
+with in the past is stored inside of the Sublime session file, allowing you to
+easily switch between projects.
+
+One issue with this mechanism is that if a project no longer exists, there is
+no straight forward way to remove it from the list of projects in the project
+switcher.
+
+This directory contains a script for Python 3 that will load up the Sublime
+session file and remove from the list of recent workspaces all of the entries
+for projects that no longer exist.
+
+
+### Usage
+
+In order to use this script, you must have Python 3 installed on your computer,
+since this is an external script and not a Sublime plugin. Additionally, make
+sure that Sublime isn't running while you run the script, since the session
+file is persisted to disk on exit, which will make Sublime restore its in-
+memory version of the session.
+
+If you're not running a Portable version of Sublime, you can just run the
+script directly in the manner that you would normally execute a Python script
+on your platform. The script will determine what platform you're on and use
+that information to locate the Sublime session file.
+
+If you are using a Portable version of Sublime, then you need to invoke the
+script with a command line argument that tells it where the Data directory is,
+so that the Sublime session file can be found. This can be a fully qualified
+path or a path relative to the current working directory.
+
+The script works by loading up the session, finding the list of recent work
+spaces, and then checking each one to see if it still exists or not. Any files
+that no longer exist will be written to the console and removed from the loaded
+session information.
+
+If any missing session files are found, the new session information is written
+out to disk. This will first create a temporary file, then rename the existing
+session file to a backup file name before renaming the temporary file into
+position.
+
+Note that no cleanup is done of session backups, so you may need to go into
+your Sublime Data directory and clean up the backups from time to time.
+
+
+### Bonus Script
+
+The folder also contains a shell script that I use to kick off this script on
+my Linux machine as a demonstration of how to use the session cleaning script
+automatically. This should work on MacOS as well, but a Windows batch file that
+does this is left as an exercise to the Windows reader.
+
+Although I manually invoke `subl` on the command line to start Sublime most of
+the time, I also have a task bar icon set up to launch it from my Linux Window
+Manager as well.
+
+For the task bar icon, this script is executed instead of directly invoking
+`subl`. The script checks to see if Sublime is already running or not, and if
+it's not it runs the session cleanup script prior to starting Sublime.
+
+This keeps things more or less automatically cleaned up, so long as I happen to
+quit Sublime for some reason.

--- a/session_cleaner/README.md
+++ b/session_cleaner/README.md
@@ -19,8 +19,8 @@ for projects that no longer exist.
 In order to use this script, you must have Python 3 installed on your computer,
 since this is an external script and not a Sublime plugin. Additionally, make
 sure that Sublime isn't running while you run the script, since the session
-file is persisted to disk on exit, which will make Sublime restore its in-
-memory version of the session.
+file is persisted to disk on exit, which will make Sublime restore its
+in-memory version of the session.
 
 If you're not running a Portable version of Sublime, you can just run the
 script directly in the manner that you would normally execute a Python script
@@ -28,22 +28,34 @@ on your platform. The script will determine what platform you're on and use
 that information to locate the Sublime session file.
 
 If you are using a Portable version of Sublime, then you need to invoke the
-script with a command line argument that tells it where the Data directory is,
+script with the `--data-dir` argument to tell it where the Data directory is,
 so that the Sublime session file can be found. This can be a fully qualified
 path or a path relative to the current working directory.
 
-The script works by loading up the session, finding the list of recent work
-spaces, and then checking each one to see if it still exists or not. Any files
-that no longer exist will be written to the console and removed from the loaded
-session information.
+The script works by loading up the session, finding the list of recent
+workspaces, and then checking each one to see if it still exists or not. Any
+files that no longer exist will be written to the console and removed from the
+loaded session information.
 
 If any missing session files are found, the new session information is written
-out to disk. This will first create a temporary file, then rename the existing
-session file to a backup file name before renaming the temporary file into
-position.
+out to disk after first making a backup of the existing session file. You can
+specify the `--dry-run` parameter to the script to have it tell you what it
+would do without actually doing it.
 
-Note that no cleanup is done of session backups, so you may need to go into
-your Sublime Data directory and clean up the backups from time to time.
+Something to note is that testing for the existence of a file on a network
+share or external disk that is not currently connected or mounted results in a
+determination that the file does not exist (technically accurate but somewhat
+unhelpful).
+
+As such, if you tend to use projects stored in those locations, you may want to
+use `--dry-run` to verify that existing but currently unavailable workspaces are
+not going to be removed.
+
+If you don't heed that advice, you can always get your previous session back
+from the session backups.
+
+Lastly, no cleanup is done of session backups, so you may need to go into your
+Sublime Data directory and clean up the backups from time to time.
 
 
 ### Bonus Script

--- a/session_cleaner/sublime_gui.sh
+++ b/session_cleaner/sublime_gui.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# If sublime is not running, check if we should clean the session
+if ! pgrep -x subl > /dev/null
+then
+    sublime_session_clean.py
+fi
+
+# Run with our arguments
+subl $*

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -1,0 +1,103 @@
+#!/bin/env python3
+"""
+Load the Session.sublime_session file from the Sublime Text 3 data directory
+and remove all of the recent workspaces that refer to projects that no longer
+reside on disk.
+
+If no command line arguments are provided, the script will look for the session
+file in the data directory location standard for the current platform. When a
+command line argument is provided, it's assumed to the location of the Data
+folder to use, which can be relative to the current directory or an absolute
+path.
+
+This creates the new session file (if any) to a temporary file first and them
+renames the session into place. During this process the original session file
+is stored as a backup in a file with the current date and time appended.
+
+This script shouldn't be run while Sublime is actively running, since the
+session information will be written out to disk when Sublime terminates, which
+will cause the changes to be ignored.
+"""
+
+from datetime import datetime
+import json
+import logging
+import os
+import sys
+
+
+def sublime_data_dir():
+    """
+    Obtain the path to the Sublime Text 3 Data directory. If the script was
+    provided any arguments, the first one is assumed to be the data directory
+    to work with; otherwise the Data directory is selected by platform.
+    """
+    if len(sys.argv) > 1:
+        return sys.argv[0]
+
+    if sys.platform.startswith("linux"):
+        return os.path.expanduser("~/.config/sublime-text-3/")
+    elif sys.platform.startswith("win"):
+        return os.path.expandvars("$APPDATA\\Sublime Text 3\\")
+
+    return os.path.expanduser("~/Library/Application Support/Sublime Text 3/")
+
+
+def clean_session():
+    """
+    Load the session file from the data directory and remove all of the
+    projects that no longer exist on disk, writing the session back.
+
+    This attempts to keep a backup of the existing session file and creates a
+    temporary session first in case things go pear shaped.
+    """
+    data_dir = sublime_data_dir()
+    session_file = os.path.join(data_dir, "Local", "Session.sublime_session")
+    tmp_file = session_file + ".tmp"
+    bkp_file = session_file + datetime.now().strftime(".%Y%m%d_%H%M%S")
+
+    logging.info("Using Data Directory: %s", data_dir)
+    try:
+        with open(session_file, encoding="utf-8") as file:
+            session = json.load(file)
+
+        workspaces = session["workspaces"]["recent_workspaces"]
+        present, missing = [], []
+        for f in workspaces:
+            present.append(f) if os.path.isfile(f) else missing.append(f)
+
+        if len(present) == len(workspaces):
+            return logging.info("No missing projects found")
+
+        for file in missing:
+            logging.info("  %s", file)
+        logging.info("Expunged %d workspace(s)", len(missing))
+
+        workspaces[:] = present
+        with open(tmp_file, "w", encoding="utf-8") as file:
+            json.dump(session, file,
+                      indent="\t",
+                      ensure_ascii=False,
+                      sort_keys=True,
+                      separators=(',', ': '))
+
+        os.rename(session_file, bkp_file)
+        os.rename(tmp_file, session_file)
+
+        logging.info("New session file saved")
+
+    except FileNotFoundError:
+        logging.exception("Unable to locate session file")
+    except KeyError:
+        logging.exception("Unable to find recent workspace list")
+    except OSError:
+        logging.exception("Error replacing session information")
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    clean_session()
+
+
+if __name__ == "__main__":
+    main()

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -10,13 +10,13 @@ command line argument is provided, it's assumed to the location of the Data
 folder to use, which can be relative to the current directory or an absolute
 path.
 
-This creates the new session file (if any) to a temporary file first and them
+This creates the new session file (if any) to a temporary file first and then
 renames the session into place. During this process the original session file
 is stored as a backup in a file with the current date and time appended.
 
 This script shouldn't be run while Sublime is actively running, since the
 session information will be written out to disk when Sublime terminates, which
-will cause the changes to be ignored.
+will cause the changes made by this script to be ignored.
 """
 
 from datetime import datetime

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -92,6 +92,14 @@ def workspace_exists(file_name):
     Given a file name that represents a Sublime project or workspace, return a
     determination as to whether that project is still valid or not.
     """
+    if sys.platform.startswith("win") and not file_name.startswith("//"):
+        # On Windows, Sublime stores local paths as '/drive/path/file/', which
+        # Python doesn't recognize as valid, so we need to rewrite them. UNC
+        # paths work OK (presuming the network is up to it).
+        file_name = "{drive}:{path}".format(
+            drive=file_name[1],
+            path=file_name[2:])
+
     return os.path.isfile(file_name)
 
 
@@ -116,6 +124,7 @@ def clean_session(data_dir):
             status_list.append(file)
 
         if len(present) != len(workspaces):
+            logging.info("Expunging defunct workspaces:")
             for file in missing:
                 logging.info("  %s", file)
             logging.info("Expunged %d workspace(s)", len(missing))


### PR DESCRIPTION
This includes a version of the script I use locally to remove defunct
projects from Sublime so that they're not offered in the project quick
switch panel.

In use it loads up the `Session.sublime-session` file and removes any
workspace entries that reference files that don't seem to exist any
longer. Backups are kept of the session files as well.

The script attempts to determine the appropriate data directory based
on the platform you run it on and also allows you to specify a data
directory specifically on the command line as well.