### PR TITLE
Include log_toggler.py

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -49,7 +49,7 @@ of each file for more information on full usage.
  * [log_toggler.py](log_toggler.py) is an example `ApplicationCommand` that
    makes it easier to toggle the state of logging for commands, input and
    result regular expressions (useful for testing error capturing in a build
-   system) without having to drop the the console. It's also a demonstration on
+   system) without having to drop to the console. It's also a demonstration on
    how to use the `is_checked` and `description` methods of the command classes
    to give your command a default caption or display as checked in the menu.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -37,7 +37,7 @@ of each file for more information on full usage.
    Files result buffer and have the line numbers that precede the text be
    removed automatically.
 
-* [generate_cmd_list.py](generate_cmd_list.py) is a sample command that
+ * [generate_cmd_list.py](generate_cmd_list.py) is a sample command that
    introspects the Sublime runtime environment and provides a textual display
    of all known commands (except for those implemented directly in the Sublime
    core), sorted out by package and type (`ApplicationCommand`, `WindowCommand`
@@ -45,6 +45,13 @@ of each file for more information on full usage.
 
    Each command also includes the arguments the command takes and any defaults
    they might have, as well as the associated documentation comment.
+
+ * [log_toggler.py](log_toggler.py) is an example `ApplicationCommand` that
+   makes it easier to toggle the state of logging for commands, input and
+   result regular expressions (useful for testing error capturing in a build
+   system) without having to drop the the console. It's also a demonstration on
+   how to use the `is_checked` and `description` methods of the command classes
+   to give your command a default caption or display as checked in the menu.
 
  * [minimap_toggler.py](minimap_toggler.py) is a simple example of having the
    sublime text minimap turn itself off only for files of a certain syntax.

--- a/plugins/log_toggler.py
+++ b/plugins/log_toggler.py
@@ -1,0 +1,69 @@
+import sublime
+import sublime_plugin
+
+# This plugin provides a command that you can use to toggle the state of the
+# three internal Sublime logging commands on and off. It takes as an argument
+# the type of logging to toggle, which can be one of "log_commands",
+# "log_input" or "log_result_regex".
+#
+# Note that the plugin assumes that you're only using these commands to change
+# the state of the logging; since there is no API for getting the current state
+# for the log toggles, the command here can't detect if you've changed the
+# state of the logging via some external mechanism.
+#
+# This could be used in a key binding as well as in a sublime-commands or
+# sublime-menu file.
+#
+# In a sublime-menu, the command will display as checked when logging for that
+# type of log is enabled if  you include the "checkbox" attribute to the menu
+# entry. The command also has a default description which displays what command
+# it will execute when it's selected.
+#
+# As an example, you can add the following to a file named Context.sublime-menu
+# in your User package to include the commands in the context menu.
+#
+# [
+    # { "caption": "-", "id": "end" },
+    # {
+    #     "command": "toggle_sublime_logging",
+    #     "checkbox": true,
+    #     "caption": "Log Commands",
+    #     "args": {"log_type": "log_commands"},
+    # },
+    # {
+    #     "command": "toggle_sublime_logging",
+    #     "checkbox": true,
+    #     "caption": "Log Input",
+    #     "args": {"log_type": "log_input"},
+    # },
+    # {
+    #     "command": "toggle_sublime_logging",
+    #     "checkbox": true,
+    #     "caption": "Log Result Regex",
+    #     "args": {"log_type": "log_result_regex"},
+    # },
+# ]
+
+
+_log_state = {
+    "log_commands": False,
+    "log_input": False,
+    "log_result_regex": False
+}
+
+
+class ToggleSublimeLoggingCommand(sublime_plugin.ApplicationCommand):
+    """
+    Toggle the state of sublime's internal logging to the console based on the
+    log_type parameter, which should be one of the three sublime module API
+    endpoints, "log_command", "log_inoput" or "log_result_regex".
+    """
+    def run(self, log_type):
+        _log_state[log_type] = not _log_state[log_type]
+        getattr(sublime, log_type)(_log_state[log_type])
+
+    def description(self, log_type):
+        return "sublime.{0}({1})".format(log_type, not _log_state[log_type])
+
+    def is_checked(self, log_type):
+        return _log_state[log_type]

--- a/plugins/log_toggler.py
+++ b/plugins/log_toggler.py
@@ -42,21 +42,28 @@ import sublime_plugin
     #     "caption": "Log Result Regex",
     #     "args": {"log_type": "log_result_regex"},
     # },
+    # {
+    #     "command": "toggle_sublime_logging",
+    #     "checkbox": true,
+    #     "caption": "Log Build Systems",
+    #     "args": {"log_type": "log_build_systens"},
+    # }
 # ]
 
 
 _log_state = {
     "log_commands": False,
     "log_input": False,
-    "log_result_regex": False
+    "log_result_regex": False,
+    "log_build_systems": False
 }
 
 
 class ToggleSublimeLoggingCommand(sublime_plugin.ApplicationCommand):
     """
-    Toggle the state of sublime's internal logging to the console based on the
+    Toggle the state of Sublime's internal logging to the console based on the
     log_type parameter, which should be one of the three sublime module API
-    endpoints, "log_command", "log_inoput" or "log_result_regex".
+    endpoints, "log_command", "log_input" or "log_result_regex".
     """
     def run(self, log_type):
         _log_state[log_type] = not _log_state[log_type]


### PR DESCRIPTION
This includes a simple plugin that allows you to easily toggle the state
of the various logging mechanisms in Sublime on and off using a key
binding, command palette entry or menu item.

This also serves as a simple demonstration of using the `is_checked` and
`description` methods of the command classes to customize how a command
appears in the menu.

As there is no API for determining the current state of the logging
flags, the command tracks the current state itself, which means that it
will get out of sync with reality if you use some external mechanism to
toggle the logging.

This will clear itself up the next time you invoke the command (although
it may appear to do nothing), but on the whole this is probably not that
important since you likely already know what you're doing in that case.