### PR TITLE
Update the session cleaner to support Merge also

### DIFF
--- a/session_cleaner/README.md
+++ b/session_cleaner/README.md
@@ -1,54 +1,58 @@
 Sublime Session Cleaner
 -----------------------
 
-As you work with Projects in Sublime, the list of projects that you've worked
-with in the past is stored inside of the Sublime session file, allowing you to
-easily switch between projects.
+As you work with Projects in Sublime Text or repositories in Sublime Merge, the
+list of items that you've worked with in the past is stored inside of the
+Sublime session file, allowing you to easily and quickly switch between them.
 
-One issue with this mechanism is that if a project no longer exists, there is
-no straight forward way to remove it from the list of projects in the project
-switcher.
+One issue with this mechanism is that if a project or repository no longer
+exists, there is no straight forward way to remove it from the list of recent
+items.
 
 This directory contains a script for Python 3 that will load up the Sublime
-session file and remove from the list of recent workspaces all of the entries
-for projects that no longer exist.
+session file for either Sublime Text or Sublime Merge and remove from the list
+of recent items all of the entries for things that no longer exist.
 
 
 ### Usage
 
 In order to use this script, you must have Python 3 installed on your computer,
 since this is an external script and not a Sublime plugin. Additionally, make
-sure that Sublime isn't running while you run the script, since the session
-file is persisted to disk on exit, which will make Sublime restore its
-in-memory version of the session.
+sure that Sublime (Text or Merge) isn't running while you run the script, since
+the session file is persisted to disk on exit, which will make Sublime restore
+its in-memory version of the session.
 
-If you're not running a Portable version of Sublime, you can just run the
+You can use the `--program` command line argument to specify whether you want
+to clean the recent items for Sublime Text or Sublime Merge, with the default
+being Sublime Text.
+
+If you're **not** running a Portable version of Sublime, you can just run the
 script directly in the manner that you would normally execute a Python script
 on your platform. The script will determine what platform you're on and use
 that information to locate the Sublime session file.
 
-If you are using a Portable version of Sublime, then you need to invoke the
+If you **are** using a Portable version of Sublime, then you need to invoke the
 script with the `--data-dir` argument to tell it where the Data directory is,
 so that the Sublime session file can be found. This can be a fully qualified
 path or a path relative to the current working directory.
 
-The script works by loading up the session, finding the list of recent
-workspaces, and then checking each one to see if it still exists or not. Any
-files that no longer exist will be written to the console and removed from the
-loaded session information.
+The script works by loading up the session, finding the list of recent items,
+and then checking each one to see if it still exists or not. Any project files
+or repositories that no longer exist will be written to the console and removed
+from the loaded session information.
 
-If any missing session files are found, the new session information is written
-out to disk after first making a backup of the existing session file. You can
-specify the `--dry-run` parameter to the script to have it tell you what it
-would do without actually doing it.
+If any missing items are found, the new session information is written out to
+disk after first making a backup of the existing session file. You can specify
+the `--dry-run` parameter to the script to have it tell you what it would do
+without actually doing it.
 
-Something to note is that testing for the existence of a file on a network
-share or external disk that is not currently connected or mounted results in a
-determination that the file does not exist (technically accurate but somewhat
-unhelpful).
+Something to note is that testing for the existence of a file or directory on a
+network share or external disk that is not currently connected or mounted
+results in a determination that the path does not exist (technically accurate
+but somewhat unhelpful).
 
-As such, if you tend to use projects stored in those locations, you may want to
-use `--dry-run` to verify that existing but currently unavailable workspaces are
+As such, if you tend to work with items stored in those locations, you may want
+to use `--dry-run` to verify that existing but currently unavailable items are
 not going to be removed.
 
 If you don't heed that advice, you can always get your previous session back
@@ -62,8 +66,11 @@ Sublime Data directory and clean up the backups from time to time.
 
 The folder also contains a shell script that I use to kick off this script on
 my Linux machine as a demonstration of how to use the session cleaning script
-automatically. This should work on MacOS as well, but a Windows batch file that
-does this is left as an exercise to the Windows reader.
+automatically to clean up Sublime Text projects.
+
+This should work on MacOS as well, but a Windows batch file that does this is
+left as an exercise to the Windows reader. A similar item could be constructed
+for Sublime Merge as well using a similar design.
 
 Although I manually invoke `subl` on the command line to start Sublime most of
 the time, I also have a task bar icon set up to launch it from my Linux Window

--- a/session_cleaner/sublime_gui.sh
+++ b/session_cleaner/sublime_gui.sh
@@ -3,7 +3,7 @@
 # If sublime is not running, check if we should clean the session
 if ! pgrep -x subl > /dev/null
 then
-    sublime_session_clean.py
+    sublime_session_clean.py --program text
 fi
 
 # Run with our arguments

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -48,7 +48,7 @@ def sublime_data_dir(prog):
     if sys.platform.startswith("linux"):
         return os.path.expanduser(_data_dirs[prog]["linux"])
     elif sys.platform.startswith("win"):
-        return os.path.expanduser(_data_dirs[prog]["win"])
+        return os.path.expandvars(_data_dirs[prog]["win"])
 
     return os.path.expanduser(_data_dirs[prog]["osx"])
 


### PR DESCRIPTION
This modifies the existing session cleaning script so that it can clean
up the list of recent repositories in Sublime Merge similarly to how it
can clean up entries for defunct projects in Sublime Text.

The structure of the code remains largely the same, with slight tweaks
to the logic in some key locations based on the program being cleaned.

For backwards compatibility the default for the new `--program` command
line argument is `text`.