### PR TITLE
Add some recent scraps to the official repository

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -109,3 +109,24 @@ of each file for more information on full usage.
    useful - for example, wrapping line comments! - so it became quite a lot more
    advanced. It now also makes it easier to join consecutive comment lines
    together by pressing <kbd>delete</kbd> at the end of the first line.
+
+ * [open_file_env.py](open_file_env.py) implements an enhanced version of the
+   `open_file` command in Sublime that will expand all of the `sublime-build`
+   variables as well as environment variables in it's `file` argument. Useful
+   for creating key bindings or menu entries to open files in the context of
+   your current project, for example.
+
+ * [open_file_encoded.py](open_file_encoded.py) is an implementation of the
+   `open_file` command in Sublime that allows you to encode a position to open
+   the file at by adding `:line` or `:line:col` to the file name, as you can on
+   the command line.
+
+ * [menu_exec.py](menu_exec.py) is a simple `exec` command variant for running
+   external tools from outside of build systems. It does what `exec` does, but
+   also expands variables in its arguments like a `sublime-build`file  would.
+   You can also stop the build output panel from displaying, if desired.
+
+ * [scoped_snippet.py](scoped_snippet.py) is an enhanced version of the
+   `insert_snippet` command that allows you to specify a scope where the
+   snippet will apply, for use in menu or command palette entries, where it's
+   not otherwise possible to constrain the scope.

--- a/plugins/menu_exec.py
+++ b/plugins/menu_exec.py
@@ -1,0 +1,51 @@
+import sublime
+import sublime_plugin
+
+from Default.exec import ExecCommand
+
+# Related reading/viewing;
+#     https://stackoverflow.com/questions/56934013/sublimetext-run-the-exec-with-current-file-as-arg-tab-context-menu
+#     https://youtu.be/WxiMlhOX_Ng
+
+# This plugin is a combination of an exec variant written for a stack overflow
+# answer and one from my YouTube video on common custom build targets.
+#
+# The internal exec command can execute external programs, but unless it is
+# invoked via the build command as a part of a build system, variables like
+# $file and the like are not expanded. This makes key bindings or menu entries
+# that want to execute specific tasks in context harder or impossible to do.
+#
+# In addition the exec command uses the global show_panel_on_build setting to
+# open the build output, which may also not be desirable if you're executing
+# ad-hoc programs.
+#
+# This variant of the command expands variables the same way as they would be
+# expanded in a build system, and also supports a custom argument named
+# override_panel to temporarily invert the state of the show_panel_on_build
+# setting.
+
+class MenuExecCommand(ExecCommand):
+    """
+    A simple wrapper around the internal exec command that expands all of the
+    normal build variables prior to the build, while also being able to
+    temporarily supress the build output panel if desired.
+    """
+    def run(self, **kwargs):
+        variables = self.window.extract_variables()
+
+        for key in ("cmd", "shell_cmd", "working_dir"):
+            if key in kwargs:
+                kwargs[key] =  sublime.expand_variables(kwargs[key], variables)
+
+        settings = sublime.load_settings("Preferences.sublime-settings")
+        show_panel = settings.get("show_panel_on_build")
+
+        override = kwargs.pop("override_panel", False)
+
+        if override:
+            settings.set("show_panel_on_build", not show_panel)
+
+        super().run(**kwargs)
+
+        if override:
+            settings.set("show_panel_on_build", show_panel)

--- a/plugins/menu_exec.py
+++ b/plugins/menu_exec.py
@@ -21,16 +21,17 @@ from Default.exec import ExecCommand
 #
 # This variant of the command expands variables the same way as they would be
 # expanded in a build system, and also supports a custom argument named
-# override_panel to temporarily invert the state of the show_panel_on_build
-# setting.
+# show_panel that controls if the output panel should be displayed or not. A
+# value of None honors the show_panel_on_build setting; set it to True or False
+# to explicitly show or not show the panel.
 
 class MenuExecCommand(ExecCommand):
     """
     A simple wrapper around the internal exec command that expands all of the
     normal build variables prior to the build, while also being able to
-    temporarily supress the build output panel if desired.
+    temporarily suppress the build output panel if desired.
     """
-    def run(self, **kwargs):
+    def run(self, show_panel=None, **kwargs):
         variables = self.window.extract_variables()
 
         for key in ("cmd", "shell_cmd", "working_dir"):
@@ -38,14 +39,14 @@ class MenuExecCommand(ExecCommand):
                 kwargs[key] =  sublime.expand_variables(kwargs[key], variables)
 
         settings = sublime.load_settings("Preferences.sublime-settings")
-        show_panel = settings.get("show_panel_on_build")
+        pref_var = settings.get("show_panel_on_build")
 
-        override = kwargs.pop("override_panel", False)
+        show_panel = pref_var if show_panel is None else show_panel
 
-        if override:
-            settings.set("show_panel_on_build", not show_panel)
+        if show_panel != pref_var:
+            settings.set("show_panel_on_build", show_panel)
 
         super().run(**kwargs)
 
-        if override:
-            settings.set("show_panel_on_build", show_panel)
+        if show_panel != pref_var:
+            settings.set("show_panel_on_build", pref_var)

--- a/plugins/open_file_encoded.py
+++ b/plugins/open_file_encoded.py
@@ -1,0 +1,32 @@
+import sublime
+import sublime_plugin
+
+# Related reading;
+#     https://stackoverflow.com/questions/56611586/open-file-at-specific-line-number-using-open-file-command
+#     https://forum.sublimetext.com/t/open-file-at-specific-line-number-using-open-file-command/41928
+
+# The open_file command from core Sublime can be used in key bindings, menu
+# entries the command palette or even from plugins to open files. From the
+# command line, Sublime allows you to optionally encode a position to open the
+# file at via adding :line or :line:col to the end of the file name.
+#
+# Unfortunately, the open_file command does not support this, but this drop in
+# replacement does. Using it, you can easily open files at exact locations if
+# desired.
+#
+# There is also a similar plugin available in the forum thread linked above
+# which adds similar functionality but uses a different mechanism for
+# specifying the line and column information.
+
+import sublime
+import sublime_plugin
+
+
+class OpenFileEncodedCommand(sublime_plugin.WindowCommand):
+    """
+    A simple drop in replacement for the open_file command that allows file
+    names with a :row or row:col position encoded at the end for opening files
+    at a specific location.
+    """
+    def run(self, file):
+        self.window.open_file(file, sublime.ENCODED_POSITION)

--- a/plugins/open_file_env.py
+++ b/plugins/open_file_env.py
@@ -1,0 +1,34 @@
+import sublime
+import sublime_plugin
+
+import os
+
+# Related reading
+#     https://forum.sublimetext.com/t/can-i-use-env-variable-in-paths-of-sublime-commands/46437
+
+# The internal open_file command can be used to open specifically named files
+# (say as part of a key binding or menu entry) and supports the $platform and
+# $packages variables, but no others.
+#
+# This plugin implements a drop-in replacement for the open_file command that
+# will not only expand all of the variables usually available in a sublime-
+# build file, but all environment variables as well.
+#
+# The original use case was to share one configuration file across multiple
+# machines where the same files exist in different places by using an
+# environment variable. It could be used for a variety of tasks, however.
+
+class OpenFileEnvCommand(sublime_plugin.WindowCommand):
+    """
+    Drop in replacement for the open_file command that expands environment
+    variables as well as standard Sublime variables in all command arguments.
+    """
+    def run(self, **kwargs):
+        # Create a set of variables based on the current process environment
+        # and the standard Sublime variables
+        variables = dict(os.environ)
+        variables.update(self.window.extract_variables())
+
+        # Expand all variables and execute the base command with them
+        kwargs = sublime.expand_variables(kwargs, variables)
+        self.window.run_command("open_file", kwargs)

--- a/plugins/scoped_snippet.py
+++ b/plugins/scoped_snippet.py
@@ -25,5 +25,5 @@ class InsertScopedSnippetCommand(sublime_plugin.TextCommand):
         if scope is None:
             return True
 
-        match = [self.view.match_selector(s.b, scope) for s in self.view.sel()]
+        match = (self.view.match_selector(s.b, scope) for s in self.view.sel())
         return all(match) if match_all else any(match)

--- a/plugins/scoped_snippet.py
+++ b/plugins/scoped_snippet.py
@@ -1,0 +1,29 @@
+import sublime
+import sublime_plugin
+
+# A snippet file can contain a scope to constrain when it will expand via the
+# tab trigger and appear in the command palette, but the insert_snippet command
+# will always insert the snippet regardless of scope. When bound to a key you
+# can use a context to also constrain the snippet, but this isn't possible in
+# the command palette or a menu item.
+#
+# This plugin implements a wrapper on that command for enabling this in those
+# locations. It lets you specify a scope to match (and whether it should match
+# all cursors or not) and will only enable itself in the appropriate scope.
+
+class InsertScopedSnippetCommand(sublime_plugin.TextCommand):
+    """
+    Drop in replacement for the insert_snippet command that will only insert
+    the snippet when the scope at the cursor location matches the scope
+    provided (if any). match_all controls whether the scope must match at all
+    cursor locations or just some of them.
+    """
+    def run(self, edit, scope=None, match_all=True, **kwargs):
+        self.view.run_command("insert_snippet", kwargs)
+
+    def is_enabled(self, scope=None, match_all=True, **kwargs):
+        if scope is None:
+            return True
+
+        match = [self.view.match_selector(s.b, scope) for s in self.view.sel()]
+        return all(match) if match_all else any(match)


### PR DESCRIPTION
This includes four recent-ish sample plugins to the official scraps
repository; three come from stack overflow/forum responses for specific
functionality and the fourth (scopes_snippet.py) is something that was
written outside of either of those situations.

In brief (see the README for more specific details):

 * `open_file_encoded.py`: open files with encoded positions
 * `open_file_env.py`: open files while expanding env vars and variables
 * `menu_exec.py`: expand build vars outside of builds and hide output
 * `scoped_snippet.py`: add external scope matching to snippets