### PR TITLE
Enhance session cleaning script

### DIFF
--- a/session_cleaner/README.md
+++ b/session_cleaner/README.md
@@ -4,10 +4,12 @@ Sublime Session Cleaner
 As you work with Projects in Sublime Text or repositories in Sublime Merge, the
 list of items that you've worked with in the past is stored inside of the
 Sublime session file, allowing you to easily and quickly switch between them.
+Additionally, Sublime Text also tracks recently used files and folders to make
+working with them again in the future easier.
 
 One issue with this mechanism is that if a project or repository no longer
-exists, there is no straight forward way to remove it from the list of recent
-items.
+exists (or a file or folder has been removed), there is no straight forward way
+to remove it from the list of recent items.
 
 This directory contains a script for Python 3 that will load up the Sublime
 session file for either Sublime Text or Sublime Merge and remove from the list
@@ -36,14 +38,31 @@ script with the `--data-dir` argument to tell it where the Data directory is,
 so that the Sublime session file can be found. This can be a fully qualified
 path or a path relative to the current working directory.
 
+When you run the script, you must specify the items that you would like to have
+cleaned out of the session file by using the following command line arguments.
+Note that Sublime Merge only supports the first argument, but providing the
+others is harmless and will do nothing.
+
+  * `--workspaces` to clean up the list of project/workspace files (Sublime
+    Text) or git repositories (Sublime Merge) that no longer exist
+
+  * `--files` to clean up the list of recently accessed files that no longer
+    exist. (Note: If you had multiple windows open when you quit Sublime, this
+    action will trigger once for each window since they all carry their own
+    history).
+
+  * `--files` to clean up the list of recently opened folders that no longer
+    exist.
+
 The script works by loading up the session, finding the list of recent items,
-and then checking each one to see if it still exists or not. Any project files
-or repositories that no longer exist will be written to the console and removed
-from the loaded session information.
+and then checking each one to see if it still exists or not. Any items that no
+longer exist will be written to the console and removed from the loaded session
+information.
 
 If any missing items are found, the new session information is written out to
-disk after first making a backup of the existing session file. You can specify
-the `--dry-run` parameter to the script to have it tell you what it would do
+disk after first making a backup of the existing session file (the name of the
+created backup file is displayed when it is created). You can specify the
+`--dry-run` parameter to the script to have it tell you what it would do
 without actually doing it.
 
 Something to note is that testing for the existence of a file or directory on a
@@ -68,9 +87,10 @@ The folder also contains a shell script that I use to kick off this script on
 my Linux machine as a demonstration of how to use the session cleaning script
 automatically to clean up Sublime Text projects.
 
-This should work on MacOS as well, but a Windows batch file that does this is
-left as an exercise to the Windows reader. A similar item could be constructed
-for Sublime Merge as well using a similar design.
+This should work on MacOS as well (assuming the command can be found on the
+`PATH`), but a Windows batch file that does this is left as an exercise to the
+Windows reader. A similar item could be constructed for Sublime Merge as well
+using a similar design.
 
 Although I manually invoke `subl` on the command line to start Sublime most of
 the time, I also have a task bar icon set up to launch it from my Linux Window
@@ -78,7 +98,6 @@ Manager as well.
 
 For the task bar icon, this script is executed instead of directly invoking
 `subl`. The script checks to see if Sublime is already running or not, and if
-it's not it runs the session cleanup script prior to starting Sublime.
-
-This keeps things more or less automatically cleaned up, so long as I happen to
-quit Sublime for some reason.
+it's not it runs the session cleanup script prior to starting Sublime. When
+Sublime **is** running, this creates a new window; remove the `-n` argument if
+you do not want that sort of behaviour.

--- a/session_cleaner/sublime_gui.sh
+++ b/session_cleaner/sublime_gui.sh
@@ -1,10 +1,39 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# If sublime is not running, check if we should clean the session
-if ! pgrep -x subl > /dev/null
+#
+# This is meant to be invoked from the task bar or a launcher in order to start
+# Sublime; any arguments passed to the script are passed to Sublime when it's
+# launched.
+#
+# A check is done prior to the launch to see if Sublime is currently running or
+# not. If it's not, then a check is done to see if there are any defunct
+# projects in the session that can be cleaned up.
+#
+# Once the check (if any) is complete, Sublime is launched.
+#
+# Additionally, if Sublime was already running, -n is added to the list of
+# arguments so that running the script while Sublime is already running creates
+# a new window.
+#
+# Regardless, Sublime is started and passed all of the arguments the script
+# received.
+
+#
+# Check to see if Sublime is running or not.
+#
+if ! pgrep -x sublime_text > /dev/null
 then
-    sublime_session_clean.py --program text
+    #
+    # Sublime is not running, so run a check to clean the session and then
+    # start Sublime with the arguments we were given.
+    #
+    sublime_session_clean.py -p text --workspaces --files --folders
+    sublime_text $*
+else
+    #
+    # Sublime is currently running. In that case execute with the arguments
+    # that we were given, but also include -n so that a new window is created.
+    #
+    sublime_text -n $*
 fi
 
-# Run with our arguments
-subl $*

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """
 Load the Session.sublime_session file from either the Sublime Text 3 or Sublime
 Merge data directory and remove all of the recent workspaces/git repositories

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -188,20 +188,40 @@ def clean_session(data_dir, program, dry_run):
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--program",
+
+    parser = argparse.ArgumentParser(description="Clean Sublime Text/Merge session files",
+                                     epilog="At least one cleanup action must be selected",
+                                     prefix_chars="-+")
+    parser.add_argument("--program", "-p",
                         help="Specify the program to clean [Default: text]",
                         choices=["text", "merge"],
                         default="text")
-    parser.add_argument("-d", "--data-dir",
+    parser.add_argument("--data-dir", "-d",
                         help="Specify the Sublime Data directory to use")
+
     parser.add_argument("--dry-run",
                         help="Run clean but don't write the new session file",
                         action="store_true")
 
-    args = parser.parse_args()
+    actions = parser.add_argument_group("Available Cleanup Actions")
 
-    # Need to set the default last so it can pick up the program
+    actions.add_argument("--workspaces", "-w",
+                        help="Clean up recently used workspaces, projects and repositories",
+                        action="store_true")
+
+    actions.add_argument("--files", "-f",
+                        help="Clean up recently used files",
+                        action="store_true")
+
+    actions.add_argument("--folders", "-o",
+                        help="Clean up recently used folders [Default: False]",
+                        action="store_true")
+
+    args = parser.parse_args()
+    if not any([args.workspaces, args.files, args.folders]):
+        parser.error("You must specify at least one cleanup option")
+
+    # Need to set the default data_dir last so it can pick up the program.
     args.data_dir = args.data_dir or sublime_data_dir(args.program)
 
     clean_session(args.data_dir, args.program, args.dry_run)

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -174,6 +174,9 @@ def clean_session(data_dir, program, dry_run):
                     os.rename(tmp_file, session_file)
 
                     logging.info("New session file saved")
+                    logging.info("Previous session backed up to: DATA_DIR%s%s" % (
+                        os.path.sep,
+                        os.path.relpath(bkp_file, args.data_dir)))
 
                 except OSError:
                     logging.exception("Error replacing session file")

--- a/session_cleaner/sublime_session_clean.py
+++ b/session_cleaner/sublime_session_clean.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """
-Load the Session.sublime_session file from either the Sublime Text 3 or Sublime
-Merge data directory and remove all of the recent workspaces/git repositories
-that  refer to items that no longer reside on disk.
+Load the Session.sublime_session file from either the Sublime Text or Sublime
+Merge data directory and perform a cleanup operation to remove all of the
+recent workspaces, folders/git repositories, and files that are in the list of
+recently accessed items if they no longer exist on disk. The items cleaned up
+are controlled by command line arguments.
 
 If no data directory is provided on the command line, the script will look for
 the session file in the data directory location standard for the appropriate
@@ -63,9 +65,17 @@ def load_session(file_name, program):
         with open(file_name, encoding="utf-8") as file:
             session = json.load(file)
 
-            items = (session["recent"] if program == "merge"
-                else session["workspaces"]["recent_workspaces"])
-            return (session, items)
+            if program == "text":
+                items = session["workspaces"]["recent_workspaces"]
+                folders = session["folder_history"]
+                files = [w["file_history"] for w in session["windows"] ]
+                files.append(session["settings"]["new_window_settings"]["file_history"])
+            else:
+                items = session["recent"]
+                folders = None
+                files = None
+
+            return (session, items, folders, files)
 
     except FileNotFoundError:
         logging.exception("Unable to locate session file")
@@ -76,7 +86,7 @@ def load_session(file_name, program):
     except KeyError:
         logging.exception("Session file could not be parsed; invalid format?")
 
-    return (None, None)
+    return (None, None, None, None)
 
 
 def save_session(file_name, session):
@@ -121,6 +131,9 @@ def item_exists(item, program):
     Given a path that represents a workspace or repository item (based on
     program), return a determination as to whether that item is still valid or
     not.
+
+    Some code invokes this with a program of "merge" when it knows that it
+    wants to check for folders and not files, as a mild hack.
     """
     path = item_path(item, program)
 
@@ -135,37 +148,74 @@ def item_exists(item, program):
     return os.path.isdir(path) if program == "merge" else os.path.isfile(path)
 
 
-def clean_session(data_dir, program, dry_run):
+def clean_items(checked_items, program, item_name):
+    """
+    Given a list of items to check (workspace files, folders, git repositories,
+    files, etc), modify the list such that any items that no longer exist are
+    removed from the list on return. The list is modified in place.
+
+    The check done is based on the program doing the check and the item itself.
+    """
+    if checked_items is None:
+        print("No items; doing nothing")
+        return False
+
+    present, missing = [], []
+    for item in checked_items:
+        status_list = present if item_exists(item, program) else missing
+        status_list.append(item)
+
+    if len(present) != len(checked_items):
+        logging.info("Cleaning up %s:" % item_name)
+        for item in missing:
+            logging.info("  %s", item_path(item, program))
+        logging.info("Cleaned %d item(s)\n", len(missing))
+
+        checked_items[:] = present
+        return True
+
+    return False
+
+
+def clean_session(args):
     """
     Load the session file from the data directory for the specified program and
-    remove all of the projects/repositories that no longer exist on disk,
-    writing the session back.
+    perform the requested clean up operations to remove items that are marked
+    as recent but which no longer exist on disk, writing the session back.
 
     This attempts to keep a backup of the existing session file and creates a
     temporary session first in case things go pear shaped.
     """
-    session_file = os.path.join(data_dir, "Local", "Session.sublime_session")
+    session_file = os.path.join(args.data_dir, "Local", "Session.sublime_session")
     tmp_file = session_file + ".tmp"
     bkp_file = session_file + datetime.now().strftime(".%Y%m%d_%H%M%S")
 
-    logging.info("Using Data Directory: %s", data_dir)
-    session, check_items = load_session(session_file, program)
+    logging.info("Using Data Directory: %s", args.data_dir)
+    if args.dry_run:
+        logging.info("--- PERFORMING DRY RUN: No Actions will be taken! ---")
+
+    session, check_items, check_folders, check_files = load_session(session_file, args.program)
     if session is not None:
-        present, missing = [], []
-        for item in check_items:
-            status_list = present if item_exists(item, program) else missing
-            status_list.append(item)
+        check1 = check2 = check3 = False
 
-        if len(present) != len(check_items):
-            logging.info("Expunging defunct items:")
-            for item in missing:
-                logging.info("  %s", item_path(item, program))
-            logging.info("Expunged %d item(s)", len(missing))
+        if args.workspaces:
+            item_type = "recent %s" % ("workspaces" if args.program == "text" else "repositories")
+            check1 = clean_items(check_items, args.program, item_type)
 
-            if dry_run:
+        if args.folders and check_folders:
+            # Force the program to be merge because merge handles folders for us
+            # transparently, and it doesn't support the notion of recent folders
+            # anyway.
+            check2 = clean_items(check_folders, "merge", "recent folders")
+
+        if args.files and check_files:
+            for file_list in check_files:
+                check3 = clean_items(file_list, args.program, "recent files") or check3
+
+        if any((check1, check2, check3)):
+            if args.dry_run:
+                logging.info("--- PERFORMING DRY RUN: Session WILL NOT be modified ---")
                 return
-
-            check_items[:] = present
 
             tmp_file = save_session(session_file, session)
             if tmp_file is not None:
@@ -182,8 +232,7 @@ def clean_session(data_dir, program, dry_run):
                     logging.exception("Error replacing session file")
 
         else:
-            logging.info("No missing items found")
-
+            logging.info("Nothing found to clean up")
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
@@ -224,4 +273,4 @@ if __name__ == "__main__":
     # Need to set the default data_dir last so it can pick up the program.
     args.data_dir = args.data_dir or sublime_data_dir(args.program)
 
-    clean_session(args.data_dir, args.program, args.dry_run)
+    clean_session(args)


### PR DESCRIPTION
This PR includes some changes for extensions to the session cleaning script that allow it to clean up the list of recent files and folders, where previously it could only clean up workspaces/git repositories.

Since there are multiple things that can be cleaned and it's conceivable that a person may want to clean only some of them (for example there may be recently accessed folders that are only available as network shares that should be left alone) the script now requires you to tell it what you would like it to clean via the command line.

There are also some other minor enhancement as well, such as better compatibility with MacOS and cleaning up the logging to look a little better.