### PR TITLE
Add pipe_text command

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -130,3 +130,11 @@ of each file for more information on full usage.
    `insert_snippet` command that allows you to specify a scope where the
    snippet will apply, for use in menu or command palette entries, where it's
    not otherwise possible to constrain the scope.
+
+ * [pipe_text.py](pipe_text.py) is a simple demonstration of how one can pipe
+   the contents of the selection(s) or active buffer to the stdin of an
+   external shell command, and replace those selections with the stdout which
+   the program returns. This is useful for things like formatting XML, JSON
+   etc. when the reindent command can't be used (because all the text is on
+   one line etc.) and without having to wait for some slow Python program to
+   parse the text.

--- a/plugins/pipe_text.py
+++ b/plugins/pipe_text.py
@@ -10,11 +10,17 @@ class PipeTextCommand(sublime_plugin.TextCommand):
        - to the specified shell command.
        Useful for formatting XML or JSON in a quick and easy manner.
        i.e. a workaround for https://github.com/sublimehq/sublime_text/issues/3294
+       This command requires Python >= 3.5, and therefore, ST build >= 4050, and for the
+       package to have opted in to the Python 3.8 plugin host. (The User package is
+       automatically opted-in.)
     """
     def run(self, edit, shell_command):
-        if all((region.empty() for region in self.view.sel())):
+        # if not all selections are non-empty
+        if not all(self.view.sel()):
+            # use the entire buffer instead of the selections
             regions = [sublime.Region(0, self.view.size())]
         else:
+            # use the user's selections
             regions = self.view.sel()
 
         failures = False

--- a/plugins/pipe_text.py
+++ b/plugins/pipe_text.py
@@ -72,7 +72,7 @@ class PipeTextCommand(sublime_plugin.TextCommand):
             p, time_elapsed = execute_with_stdin(cmd, shell, text)
 
             # TODO: also report the selection index?
-            log(f'command "{repr(cmd)}" executed with return code {str(p.returncode)} in {time_elapsed * 1000:.3f}ms')
+            log(f'command "{cmd!r}" executed with return code {p.returncode} in {time_elapsed * 1000:.3f}ms')
 
             if p.returncode == 0:
                 self.view.replace(edit, region, p.stdout)

--- a/plugins/pipe_text.py
+++ b/plugins/pipe_text.py
@@ -3,6 +3,17 @@ import sublime_plugin
 from subprocess import run, PIPE
 import time
 from datetime import datetime
+import sys
+
+
+def execute_with_stdin(cmd, shell, text):
+    before = time.perf_counter()
+    # https://docs.python.org/3/library/subprocess.html#subprocess.run - new in version 3.5
+    # therefore, this python file should be in your User package (which defaults to Python 3.8)
+    # and you need to be using ST build >= 4050
+    p = run(cmd, shell=shell, capture_output=True, input=text, encoding='utf-8')
+    after = time.perf_counter()
+    return (p, after - before)
 
 
 class PipeTextCommand(sublime_plugin.TextCommand):
@@ -14,7 +25,7 @@ class PipeTextCommand(sublime_plugin.TextCommand):
        package to have opted in to the Python 3.8 plugin host. (The User package is
        automatically opted-in.)
     """
-    def run(self, edit, shell_command):
+    def run(self, edit, cmd=None, shell_cmd=None):
         # if not all selections are non-empty
         if not all(self.view.sel()):
             # use the entire buffer instead of the selections
@@ -22,6 +33,25 @@ class PipeTextCommand(sublime_plugin.TextCommand):
         else:
             # use the user's selections
             regions = self.view.sel()
+
+        if not shell_cmd and not cmd:
+            raise ValueError("shell_cmd or cmd is required")
+
+        if shell_cmd and not isinstance(shell_cmd, str):
+            raise ValueError("shell_cmd must be a string")
+
+        # this shell_cmd/cmd logic was borrowed from Packages/Default/exec.py
+        if shell_cmd:
+            if sys.platform == "win32":
+                # Use shell=True on Windows, so shell_cmd is passed through
+                # with the correct escaping
+                cmd = shell_cmd
+                shell = True
+            else:
+                cmd = ["/usr/bin/env", "bash", "-c", shell_cmd]
+                shell = False
+        else:
+            shell = False
 
         failures = False
         start = time.perf_counter()
@@ -32,18 +62,17 @@ class PipeTextCommand(sublime_plugin.TextCommand):
             logs.append(log_text)
             print(log_text)
 
+        # TODO: the commands could take a while to execute, and it may be an idea to not block the ui
+        # - so maybe just mark the buffer as read only until they complete and do the replacements async
+        # maybe even with some phantoms or annotations near the selections to tell the user what is going on
+
         for region in reversed(regions):
             text = self.view.substr(region)
             
-            before = time.perf_counter()
-            # https://docs.python.org/3/library/subprocess.html#subprocess.run - new in version 3.5
-            # therefore, this python file should be in your User package (which defaults to Python 3.8)
-            # and you need to be using ST build >= 4050
-            p = run(shell_command, capture_output=True, input=text, encoding='utf-8')
-            after = time.perf_counter()
+            p, time_elapsed = execute_with_stdin(cmd, shell, text)
 
             # TODO: also report the selection index?
-            log(f'command {repr(shell_command)} executed with return code {str(p.returncode)} in {(after - before) * 1000:.3f}ms')
+            log(f'command "{repr(cmd)}" executed with return code {str(p.returncode)} in {time_elapsed * 1000:.3f}ms')
 
             if p.returncode == 0:
                 self.view.replace(edit, region, p.stdout)
@@ -59,7 +88,9 @@ class PipeTextCommand(sublime_plugin.TextCommand):
 
 # example for pretty printing XML using xmllint:
 # TODO: option for no xml prolog when working with selections? https://stackoverflow.com/q/37118327/4473405
-#view.run_command('pipe_text', { 'shell_command': ['xmllint', '--format', '-'] })
+#view.run_command('pipe_text', { 'cmd': ['xmllint', '--format', '-'] })
 
 # example for pretty printing JSON using jq:
-#view.run_command('pipe_text', { 'shell_command': ['jq', '.'] })
+#view.run_command('pipe_text', { 'cmd': ['jq', '.'] })
+
+#view.run_command('pipe_text', {"shell_cmd": "sort | uniq"})

--- a/plugins/pipe_text.py
+++ b/plugins/pipe_text.py
@@ -1,0 +1,59 @@
+import sublime
+import sublime_plugin
+from subprocess import run, PIPE
+import time
+from datetime import datetime
+
+
+class PipeTextCommand(sublime_plugin.TextCommand):
+    """Pipe text from ST - the selections, if any, otherwise the entire buffer contents
+       - to the specified shell command.
+       Useful for formatting XML or JSON in a quick and easy manner.
+       i.e. a workaround for https://github.com/sublimehq/sublime_text/issues/3294
+    """
+    def run(self, edit, shell_command):
+        if all((region.empty() for region in self.view.sel())):
+            regions = [sublime.Region(0, self.view.size())]
+        else:
+            regions = self.view.sel()
+
+        failures = False
+        start = time.perf_counter()
+        logs = list()
+        def log(message):
+            nonlocal logs
+            log_text = str(datetime.now()) + ' ' + message
+            logs.append(log_text)
+            print(log_text)
+
+        for region in reversed(regions):
+            text = self.view.substr(region)
+            
+            before = time.perf_counter()
+            # https://docs.python.org/3/library/subprocess.html#subprocess.run - new in version 3.5
+            # therefore, this python file should be in your User package (which defaults to Python 3.8)
+            # and you need to be using ST build >= 4050
+            p = run(shell_command, capture_output=True, input=text, encoding='utf-8')
+            after = time.perf_counter()
+
+            # TODO: also report the selection index?
+            log(f'command {repr(shell_command)} executed with return code {str(p.returncode)} in {(after - before) * 1000:.3f}ms')
+
+            if p.returncode == 0:
+                self.view.replace(edit, region, p.stdout)
+            else:
+                failures = True
+                log(p.stderr.rstrip())
+
+        total_elapsed = time.perf_counter() - start
+        if failures:
+            sublime.error_message('\n'.join(logs)) # TODO: don't include the datetimes here?
+        else:
+            sublime.status_message(f'text piped and replaced successfully in {total_elapsed * 1000:.3f}ms')
+
+# example for pretty printing XML using xmllint:
+# TODO: option for no xml prolog when working with selections? https://stackoverflow.com/q/37118327/4473405
+#view.run_command('pipe_text', { 'shell_command': ['xmllint', '--format', '-'] })
+
+# example for pretty printing JSON using jq:
+#view.run_command('pipe_text', { 'shell_command': ['jq', '.'] })


### PR DESCRIPTION
`pipe_text` is a simple demonstration of how one can pipe the contents of the selection(s) or active buffer to the "stdin" of an external shell command, and replace those selections with the "stdout" returned from said program.
This is useful for things like formatting XML, JSON etc. when the `reindent` command can't be used (i.e. because all the text is on one line etc.) and without having to wait for some slow Python program to parse the text, or [manually doing a find and replace](https://github.com/sublimehq/sublime_text/issues/3294)...

This relies on a Python method which was added to the standard library in Python 3.5, so one needs to be using a ST 4xxx build, and to drop the plugin into the User package, or otherwise have the appropriate `.python-version` file in the package so that the Python 3.8 plugin host will be used.