### PR TITLE
fix argument name passing to context menu

### DIFF
--- a/plugins/log_toggler.py
+++ b/plugins/log_toggler.py
@@ -46,7 +46,7 @@ import sublime_plugin
     #     "command": "toggle_sublime_logging",
     #     "checkbox": true,
     #     "caption": "Log Build Systems",
-    #     "args": {"log_type": "log_build_systens"},
+    #     "args": {"log_type": "log_build_systems"},
     # }
 # ]
 


### PR DESCRIPTION
thanks for sharing this plugin! I could never remember the right command to enable logging. 

this PR adds the correct function name to the context menu.