### PR TITLE
Refresh, update and expand on custom build targets

### DIFF
--- a/build_enhancements/README.md
+++ b/build_enhancements/README.md
@@ -30,10 +30,29 @@ on its specific use.
    could be used to insert some project specific information easily into a
    build, for example.
 
+ * [timeout_exec.py](timeout_exec.py) is a custom build target that is capable
+   of cancelling a build automatically if it doesn't finish within a configured
+   time delay. There are multiple versions here depending on which version of
+   Sublime Text you're running.
+
+ * [makefile_build.py](makefile_build.py) is a custom build target that allows
+   you to select the Makefile to use from within your project by choosing it
+   from the context menu in the side bar. If you use a project structure with
+   multiple Makefiles in it for different aspects, you may find this useful.
+
  * [python_build.py](python_build.py) is an example of configuring a build
    system to have two different commands (here 32-bit and 64-bit versions of
    python) and having the first line in the file have text which tells the
    build which version to use.
+
+ * [relative_python_exec.py](relative_python_exec.py) is a Pythion centric build
+   system that allows you to execute a Python file based on it's module name
+   instead of on it's file name.
+
+ * [redirect_exec.py](redirect_exec.py) is an example of a custom build target
+   that generates a temporary file based on other information (in this case the
+   contents of the current file) and then executing it. It also demonstrates
+   detecting with a build has finished.
 
  * [shebanger.py](shebanger.py) is similar to **python_build.py** in that it
    determines what to use to perform the build from the first line of the

--- a/build_enhancements/README.md
+++ b/build_enhancements/README.md
@@ -45,14 +45,14 @@ on its specific use.
    python) and having the first line in the file have text which tells the
    build which version to use.
 
- * [relative_python_exec.py](relative_python_exec.py) is a Pythion centric build
+ * [relative_python_exec.py](relative_python_exec.py) is a Python centric build
    system that allows you to execute a Python file based on it's module name
-   instead of on it's file name.
+   instead of it's file name.
 
  * [redirect_exec.py](redirect_exec.py) is an example of a custom build target
    that generates a temporary file based on other information (in this case the
-   contents of the current file) and then executing it. It also demonstrates
-   detecting with a build has finished.
+   contents of the current file) and then executes it. It also demonstrates
+   detecting when a build has finished.
 
  * [shebanger.py](shebanger.py) is similar to **python_build.py** in that it
    determines what to use to perform the build from the first line of the

--- a/build_enhancements/custom_build_variables.py
+++ b/build_enhancements/custom_build_variables.py
@@ -1,5 +1,8 @@
 import sublime, sublime_plugin
 
+from Default.exec import ExecCommand
+
+
 # Related reading:
 #     http://stackoverflow.com/questions/40193019/set-project-dependent-build-system-variables
 
@@ -8,34 +11,34 @@ import sublime, sublime_plugin
 # our own custom build variables for cases when the ones built into Sublime are
 # not enough.
 
-# For this to work, you need to specify that the "target" is this command,
-# specify the command to execute as "command" instead of "cmd", and of course
-# provide the settings that you want to expand (such as in your project or from
-# a plugin).
+# For this to work, you need to specify that the "target" is this command, and
+# of course provide the settings that you want to expand (such as in your
+# project or from a plugin).
 #
 # An example might be:
 #
 # {
 #     "target": "my_custom_build",
-#     "command": ["build.sh", "${proj_var_1}"],
+#     "cancel": { "kill": true },
+#     "cmd": ["build.sh", "\\${proj_var_1}"],
 #
 #     "working_dir": "${project_path:${folder}}",
 #     "shell": false
 # }
 
-# Something to watch out for here is that when Sublime executes the build, it
-# does an expansion of variables that it supports internally before it passes
-# the results to the custom command. During this process, any custom variables
-# that we have added will get replaced with empty text because they are not
-# recognized.
-#
-# This only happens for fields that Sublime knows are part of a build file. That
-# is why you need to specify "command" instead of "cmd" in the build.
+# Sublime will expand all variables in the build keys for cmd, shell_cmd and
+# working_dir before it invokes your custom command target. If you want to
+# include custom variables in those, you need to escape them so that Sublime
+# will leave them alone.
 
-# List of variable names we want to support
+# List of variable names we want to support; these will come from:
+#    1. Your global preferences
+#    2. Project specific settings
+#    3. Syntax specific settings
+#    4. Buffer (file) specific overrides
 custom_var_list = ["proj_var_1"]
 
-class MyCustomBuildCommand(sublime_plugin.WindowCommand):
+class MyCustomBuildCommand(ExecCommand):
     """
     Provide custom build variables to a build system, such as a value that needs
     to be specific to a current project.
@@ -43,30 +46,16 @@ class MyCustomBuildCommand(sublime_plugin.WindowCommand):
     This example only allows for variables in the "cmd" field, but could be
     easily extended.
     """
-    def createExecDict(self, sourceDict):
-        global custom_var_list
-
-        # Get the project specific settings
-        project_data = self.window.project_data ()
-        project_settings = (project_data or {}).get ("settings", {})
-
+    def run(self, **kwargs):
         # Get the view specific settings
-        view_settings = self.window.active_view ().settings ()
+        settings = self.window.active_view().settings()
 
         # Variables to expand; start with defaults, then add ours.
-        variables = self.window.extract_variables ()
+        variables = {}
         for custom_var in custom_var_list:
-            variables[custom_var] = view_settings.get (custom_var,
-                project_settings.get (custom_var, ""))
+            variables[custom_var] = settings.get(custom_var)
 
-        # Create arguments to return by expanding variables in the
-        # arguments given.
-        args = sublime.expand_variables (sourceDict, variables)
-
-        # Rename the command parameter to what exec expects.
-        args["cmd"] = args.pop ("command", [])
-
-        return args
-
-    def run(self, **kwargs):
-        self.window.run_command ("exec", self.createExecDict (kwargs))
+        # Expand out our variables in all of the arguments, and then invoke the
+        # super method to execute the build.
+        kwargs = sublime.expand_variables(kwargs, variables)
+        super().run(**kwargs)

--- a/build_enhancements/makefile_build.py
+++ b/build_enhancements/makefile_build.py
@@ -34,7 +34,7 @@ from Default.exec import ExecCommand
 #
 # In use, your build system would use the two new variables to set up how the
 # build should execute. An example of that based on the Makefile.sublime-build
-# file that ships with Sublime is the following. It executes make telling it
+# file that ships with Sublime is the following. It executes 'make' telling it
 # what Makefile to use, and also uses the Makefile location to set the working
 # directory as appropriate.
 #
@@ -62,7 +62,7 @@ from Default.exec import ExecCommand
 
 def _get_project_settings(window):
     """
-    Get the project specific settinsg data for the provided window; this will
+    Get the project specific settings data for the provided window; this will
     work for any window since all windows carry project data.
     """
     project_data = window.project_data()

--- a/build_enhancements/makefile_build.py
+++ b/build_enhancements/makefile_build.py
@@ -1,0 +1,129 @@
+import sublime
+import sublime_plugin
+
+import os
+
+from Default.exec import ExecCommand
+
+# This is an example of a custom build target for executing a build using a
+# Makefile, but for use in situations in which there could be any number of
+# possible Makefiles, such as if there were multiple projects, etc.
+#
+# In use, the plugin provides a command that allows you to select a Makefile to
+# use during the build by selecting it from the context menu in the side bar.
+# The menu entry has a checkbox in it that will show as checked for the
+# Makefile that will be used in the next build.
+#
+# When the build executes, it will have two extra variables that will expand
+# out, 'selected_makefile' and 'selected_makefile_path' which specify the full
+# path to the selected makefile and the location in which it's stored
+# respectively.
+#
+# To use this plugin, you must create a file named "Side Bar.sublime-menu" in
+# your User package with the following content; if you already have such a file
+# then just add this entry. You can also change the caption text to be anything
+# you like.
+#
+# [
+#     { "caption": "Build with this Makefile",
+#       "checkbox": true,
+#       "command": "select_makefile",
+#       "args": {"files": []},
+#     },
+# ]
+#
+# In use, your build system would use the two new variables to set up how the
+# build should execute. An example of that based on the Makefile.sublime-build
+# file that ships with Sublime is the following. It executes make telling it
+# what Makefile to use, and also uses the Makefile location to set the working
+# directory as appropriate.
+#
+# {
+#     "target": "makefile_build",
+#     "cancel": {"kill": true},
+#
+#     "shell_cmd": "make -f \\${selected_makefile}",
+#     "working_dir": "\\${selected_makefile_path}",
+#     "file_regex": "^(..[^:\n]*):([0-9]+):?([0-9]+)?:? (.*)$",
+#
+#     "selector": "source.makefile",
+#     "syntax": "Packages/Makefile/Make Output.sublime-syntax",
+#     "keyfiles": ["Makefile", "makefile"],
+#
+#     "variants":
+#     [
+#         {
+#             "name": "Clean",
+#             "shell_cmd": "make clean"
+#         }
+#     ]
+# }
+
+
+def _get_project_settings(window):
+    """
+    Get the project specific settinsg data for the provided window; this will
+    work for any window since all windows carry project data.
+    """
+    project_data = window.project_data()
+    return project_data.get('settings', {})
+
+
+def _set_project_settings(window, settings):
+    """
+    Given a settings object, update the project data in the given window. If
+    this is a window that contains an explicit project, the sublime-project
+    file will be updated.
+    """
+    project_data = window.project_data() or {}
+    project_data['settings'] = settings
+
+    window.set_project_data(project_data)
+
+
+class SelectMakefileCommand(sublime_plugin.WindowCommand):
+    """
+    This can be executed from the side bar context menu by right clicking on
+    a Makefile and choosing the item. The selected Makefile is stored into the
+    project specific settings for this window, so that it will persist.
+    """
+    def run(self, files=[]):
+        settings = _get_project_settings(self.window)
+        settings.update({
+            'selected_makefile': files[0],
+            'selected_makefile_path': os.path.dirname(files[0])
+        })
+
+        _set_project_settings(self.window, settings)
+
+    def is_enabled(self, files=[]):
+        # Only enabled for files named Makefile regardless of case; this could
+        # be augmented to search within a list of possible names as well.
+        return len(files) == 1 and os.path.basename(files[0]).upper() == 'MAKEFILE'
+
+    def is_checked(self, files=[]):
+        settings = _get_project_settings(self.window)
+        return len(files) == 1 and files[0] == settings.get('selected_makefile', '')
+
+
+class MakefileBuildCommand(ExecCommand):
+    """
+    Enhanced version of the internal exec command that can expand out variables
+    that specify the selected Makefile and its location.
+    """
+    def run(self, **kwargs):
+        kill = kwargs.get('kill', False)
+        if kill:
+            return super().run(kill=True)
+
+        settings = _get_project_settings(self.window)
+        variables = {
+            'selected_makefile': settings.get('selected_makefile', ''),
+            'selected_makefile_path': settings.get('selected_makefile_path', '')
+        }
+
+        if variables['selected_makefile'] == '':
+            return sublime.error_message('No Makefile has been selected for this project')
+
+        kwargs = sublime.expand_variables(kwargs, variables)
+        super().run(**kwargs)

--- a/build_enhancements/python_build.py
+++ b/build_enhancements/python_build.py
@@ -52,7 +52,7 @@ class PythonBuildCommand(ExecCommand):
     def detect_version(self, filename, python32, python64):
         with open(filename, 'r') as handle:
             line = handle.readline()
-        return python64 if(line.startswith("#") and "64" in line) else python32
+        return python64 if (line.startswith ("#") and "64" in line) else python32
 
     def run(self, **kwargs):
         current_file = self.window.active_view().file_name() or ''

--- a/build_enhancements/redirect_exec.py
+++ b/build_enhancements/redirect_exec.py
@@ -1,0 +1,92 @@
+import sublime
+import sublime_plugin
+
+import os
+import tempfile
+
+from Default.exec import ExecCommand
+
+# Related Reading:
+#     https://stackoverflow.com/questions/68083252/run-a-python-snippet-with-every-run-on-sublime-text
+
+# This is an example of a build system custom target, in this case one that
+# will generate a temporary file based on the contents of the current file.
+# This plugin requires Sublime Text 4; the version of the ExecCommand class
+# subclassed here is laid out differently in ST3. To use this plugin there,
+# some changes would need to be made as outlined in the stack overflow
+# post above.
+#
+# This could be useful for things like executing only selected code or only
+# some parts of a larger file, or as in this example to augment a file with
+# extra boilerplate code that you want there while it's executing without it
+# being permanent.
+#
+# In use, the build will generate a temporary file that contains the boiler
+# plate code below and the contents of the current file. The name of the
+# temporary file is stored in the $temp_file variable in the build.
+#
+# An example build might be:
+
+# {
+#     "target": "python_with_redirect_exec",
+#     "cancel": {"kill": true},
+#
+#     "cmd": ["python3", "-u", "\\$temp_file"],
+#     "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
+#     "selector": "source.python",
+#
+#     "working_dir": "${file_path}",
+#
+#     "env": {"PYTHONIOENCODING": "utf-8"},
+#
+#     "windows": {
+#         "cmd": ["py", "-u", "\\$temp_file"],
+#     },
+# }
+
+
+_stub = """
+import sys
+sys.stdin, sys.stdout = open('input', 'r'), open('output', 'w')
+
+"""
+
+
+class PythonWithRedirectExecCommand(ExecCommand):
+    def run(self, **kwargs):
+        view = self.window.active_view()
+        if view.file_name() is None or not os.path.exists(view.file_name()):
+            return self.window.status_message("Cannot build; no file associated with the current view")
+
+        self.tmp_file = self.get_temp_file(view)
+
+        variables = {"temp_file": self.tmp_file}
+        kwargs = sublime.expand_variables(kwargs, variables)
+
+        super().run(**kwargs)
+
+    def get_temp_file(self, view):
+        handle, name = tempfile.mkstemp(text=True, suffix=".py")
+        with os.fdopen(handle, mode="wt", encoding="utf-8") as handle:
+            handle.write(_stub)
+            with open(view.file_name()) as source:
+                handle.write(source.read())
+
+        return name
+
+    def on_finished(self, proc):
+        super().on_finished(proc)
+
+        # If the current build didn't finish or it was manually killed, leave.
+        if proc != self.proc or proc.killed:
+            return
+
+        try:
+            # If the build suceeded, delete the temporary file; we will leave
+            # it alone if the build fails so that it's possible to navigate
+            # to it.
+            exit_code = proc.exit_code()
+            if exit_code == 0 or exit_code is None:
+                os.remove(self.tmp_file)
+        finally:
+            self.tmp_file = None

--- a/build_enhancements/relative_python_exec.py
+++ b/build_enhancements/relative_python_exec.py
@@ -1,0 +1,58 @@
+import sublime
+import sublime_plugin
+
+import os
+
+from Default.exec import ExecCommand
+
+# Related reading:
+#     https://forum.sublimetext.com/t/how-can-i-create-a-new-build-system-to-run-python-from-project-root/47461/2
+#
+# This is an example of a custom build target that can execute Pythion code
+# as a module by calculating the module name of the file based on the root of
+# the project. Given a folder named myProject/folder1/my_file.py, then
+# you could excecute it as "python -m folder1.my_file" with the current
+# directory being myProject.
+#
+# This exposes a new variable named module_name that represents the module name
+# of the current file.
+#
+# To use this, create a sublime-build file with contents similar to the
+# following example:
+#
+# {
+#     "target": "relative_python_exec",
+#     "cancel": {"kill": true},
+#
+#     "shell_cmd": "python -um \"\\${module_name}\"",
+#     "working_dir": "${folder}",
+#
+#     "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
+#     "selector": "source.python",
+#
+#     "env": {"PYTHONIOENCODING": "utf-8"},
+# }
+#
+
+class RelativePythonExecCommand(ExecCommand):
+    def run(self, **kwargs):
+        # Get the standard list of build variables and construct a
+        # relative path to the current file based on the first open
+        # folder
+        var_list = self.window.extract_variables()
+        rel_name = os.path.relpath(var_list["file"], var_list["folder"])
+
+        # Remove the extension and replace path separators with periods
+        rel_name = os.path.splitext(rel_name)[0].replace(os.path.sep, '.')
+
+        # Set up a new variable and then expand it in the keyword args
+        var_list["module_name"] = rel_name
+
+        # This should only expand variables in shell_cmd, cmd and working_dir
+        # if it wants to be fully compatible with exec. Or alternately you
+        # can do it this way, which allows you to expand variables in all
+        # keys if you wanted to do that.
+        kwargs = sublime.expand_variables(kwargs, var_list)
+
+        # Run the build
+        super().run(**kwargs)

--- a/build_enhancements/shebanger.py
+++ b/build_enhancements/shebanger.py
@@ -44,7 +44,7 @@ class ShebangerCommand(ExecCommand):
     """
     Command to be used as the "target" option in a build system. Based on a
     customized build system, this will modify the version of python used to
-    the one listed in the shebang line at the start of the script(if any).
+    the one listed in the shebang line at the start of the script (if any).
     """
     def parse_shebang(self, filename):
         with open(filename, 'r') as handle:

--- a/build_enhancements/timeout_exec.py
+++ b/build_enhancements/timeout_exec.py
@@ -1,0 +1,79 @@
+import sublime
+import sublime_plugin
+
+from Default.exec import ExecCommand
+
+# Related Reading:
+#     https://stackoverflow.com/q/61381000/814803
+#
+# This is an example of a custom build target that allows you to specify right
+# inside the build the maximum amount of time the build should be allowed to
+# run. If the build takes longer, it will automatically cancel itself.
+#
+# To use this, you need to include a key named "timeout" in your sublime-build
+# file that specifies how long (in seconds) the build should be allowed to
+# run. Setting it to zero or not including it will make the build run as
+# normal. An example build might look like:
+#
+# {
+#     "target": "timeout_exec",
+#     "cancel": {"kill": true},
+#
+#     "timeout": 4,
+#
+#     "shell_cmd": "echo \"Start\" && sleep 10 && echo \"Done\""
+# }
+#
+# There are two versions of this command here, the first one is for use in
+# Sublime Text 4 while the second (older) one is for Sublime Text 3. You should
+# choose and install only the one you need; if you're using ST3, make sure you
+# change the name of the class or use the appropriate command name in your
+# build file.
+
+
+class TimeoutExecCommand(ExecCommand):
+    """
+    This is a custom build target which can optionally self cancel a build if
+    it runs more than a configurable amount of time.
+
+    This version will only work in Sublime Text 4.
+    """
+    def run(self, **kwargs):
+        self.timeout = kwargs.pop("timeout", 0)
+        self.build_complete = False
+
+        super().run(**kwargs)
+
+        if self.timeout:
+            sublime.set_timeout(self.time_out_build, self.timeout * 1000)
+
+    def time_out_build(self):
+        if self.proc and not self.build_complete:
+            self.write("\n[Timeout exceeded: %.1f]" % self.timeout)
+            self.proc.kill()
+
+    def on_finished(self, proc):
+        self.build_complete = True
+        super().on_finished(proc)
+
+
+class TimeoutExecOldStyleCommand(ExecCommand):
+    """
+    This is a custom build target which can optionally self cancel a build if
+    it runs more than a configurable amount of time.
+
+    This version will only work in Sublime Text 3.
+    """
+    def run(self, **kwargs):
+        self.timeout = kwargs.pop("timeout", 0)
+
+        super().run(**kwargs)
+
+        if self.timeout:
+            sublime.set_timeout(self.time_out_build, self.timeout * 1000)
+
+    def time_out_build(self):
+        if self.proc:
+            self.append_string(self.proc, "[Timeout exceeded: %.1f]" % self.timeout)
+            self.proc.kill()
+            self.proc = None

--- a/build_enhancements/timeout_exec.py
+++ b/build_enhancements/timeout_exec.py
@@ -34,7 +34,7 @@ from Default.exec import ExecCommand
 class TimeoutExecCommand(ExecCommand):
     """
     This is a custom build target which can optionally self cancel a build if
-    it runs more than a configurable amount of time.
+    it runs for more than a configurable amount of time.
 
     This version will only work in Sublime Text 4.
     """


### PR DESCRIPTION
This updates the code for the existing custom build target examples
that we previously had so that they now subclass ExecCommand instead
of being a proxy for it and handle variables in a smarter way.

In addition, there are a variety of new custom build target examples
added in here that have been accumulated over the last year and a half
or so from various forum and stack overflow questions.
