### PR TITLE
Include some extra plugin samples

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -171,7 +171,8 @@ of each file for more information on full usage.
 
  * [selection_to_top.py](selection_to_top.py) is a quick little command I made
    for making it easier to illustrate code samples in my YouTube videos; it
-   scrolls the current file so that the cursor is the first line in the view.
+   scrolls the current file so that the cursor is the first line in the
+   viewport.
 
  * [pattern_navigate.py](pattern_navigate.py) is a simple command that allows
    you to easily jump to the next or previous location of a specified search

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -24,12 +24,28 @@ of each file for more information on full usage.
 
 ### What they do
 
+ * [clear_console.py](clear_console.py) is a simple plugin that implements a
+   command that lets you clear the Sublime Text console. This is done by
+   manipulating the setting that controls how much history can be kept in the
+   console. The setting used was added in Sublime Text 4.
+
  * [double_click.py](double_click.py) is an example of how to use the Sublime
    API to emulate a double click somewhere in the view. This involves
    converting a caret position offset to window coordinates and calling a built
    in command that handles mouse clicks. This is useful for cases where double
    clicking would otherwise be the only way to access some functionality, but
    one doesn't want to have to move a hand off the keyboard to the mouse.
+
+ * [insert_to_column.py](insert_to_column.py) is a sample that was made for
+   someone so grumpy they never came back to say thanks, but their loss may be
+   your gain! It implements a command that causes whitespace to be inserted at
+   every cursor until it hits a specific column. Aligning columns and table
+   entries just got a bit easier.
+
+ * [eof_context.py](eof_context.py) is an example of implementing a custom key
+   binding context, which is used to control when a key binding should be
+   active. This one implements a context that lets you know if the cursor is
+   in the last line of the file or not.
 
  * [find_results_copy.py](find_results_copy.py) is an example of seamlessly
    expanding the capabilities of Sublime to make it work the way you want. This
@@ -98,6 +114,10 @@ of each file for more information on full usage.
    environment of Sublime while it's running to allow you to run Visual Studio
    commands in build systems.
 
+ * [local_font_size.py](local_font_size.py) provides commands that allow you to
+   change the font size of individual tabs instead of changing it globally,
+   which can be handy for things like code review or doing a presentation.
+
  * [toggle_setting_ext.py](toggle_setting_ext.py) is a version of the internal
    sublime `toggle_setting` command that can toggle any setting between any
    value, instead of just toggling a boolean setting off and on.
@@ -131,6 +151,11 @@ of each file for more information on full usage.
    snippet will apply, for use in menu or command palette entries, where it's
    not otherwise possible to constrain the scope.
 
+  * [snippets_with_selections.py](snippets_with_selections.py) is an enhanced
+    version of the `insert_snippet` command that allows the expanded text to
+    access each of many possible selections individually instead of one that
+    covers all selections.
+
  * [pipe_text.py](pipe_text.py) is a simple demonstration of how one can pipe
    the contents of the selection(s) or active buffer to the stdin of an
    external shell command, and replace those selections with the stdout which
@@ -138,3 +163,30 @@ of each file for more information on full usage.
    etc. when the reindent command can't be used (because all the text is on
    one line etc.) and without having to wait for some slow Python program to
    parse the text.
+
+ * [selectionless_scroll_lines.py](selectionless_scroll_lines.py) is something
+   that was requested by someone, though I can't find where the request came
+   from. It allows you to scroll the file using the keyboard without changing
+   the cursor locations.
+
+ * [selection_to_top.py](selection_to_top.py) is a quick little command I made
+   for making it easier to illustrate code samples in my YouTube videos; it
+   scrolls the current file so that the cursor is the first line in the view.
+
+ * [pattern_navigate.py](pattern_navigate.py) is a simple command that allows
+   you to easily jump to the next or previous location of a specified search
+   string. This is meant to be used in a macro, but you could also use it to
+   always jump to a known location (like a file footer, section header, etc).
+
+ * [scope_navigate.py](scope_navigate.py) is a command that allows you to jump
+   to the next or previous location of a given `scope` in the file. This could
+   be used to jump between comments, code blocks, etc.
+
+ * [update_last_edited.py](update_last_edited.py) is a quick plugin example that
+   can be used to easily update a "Last Edited On" type header in any source
+   file quickly and easily.
+
+ * [visible_multi_selection.py](visible_multi_selection.py) makes it easier to
+   visibly detect when there is more than one active cursor in the current file
+   by changing cursor settings (e.g. making the cursor wider) when there is more
+   than one.

--- a/plugins/clear_console.py
+++ b/plugins/clear_console.py
@@ -1,0 +1,38 @@
+import sublime
+import sublime_plugin
+
+# This implements a command named "clear_console" that will clear the contents
+# of the Sublime Text console. This will only work in Sublime Text 4.
+#
+# You can create a key binding on this such as the following (the context makes
+# it only apply while the console has the focus):
+#
+# { "keys": ["super+t"], "command": "clear_console",
+#   "context": [
+#       { "key": "panel", "operand": "console" },
+#       { "key": "panel_has_focus"  }
+#   ]
+# },
+#
+# Alternately, you can create a file named "Widget Context.sublime-menu" in
+# your User package to add a context menu item that you can use in the console
+# body as well:
+#
+# [
+#     { "caption": "-" },
+#     { "command": "clear_console" },
+# ]
+#
+
+
+class ClearConsoleCommand(sublime_plugin.ApplicationCommand):
+    """
+    Clear out the Sublime console by temporarily setting the scroll back length
+    to a single line and outputting a line, causing the history to be dropped.
+    """
+    def run(self):
+        s = sublime.load_settings('Preferences.sublime-settings')
+        scrollback = s.get('console_max_history_lines')
+        s.set('console_max_history_lines', 1)
+        print("")
+        s.set('console_max_history_lines', scrollback)

--- a/plugins/eof_context.py
+++ b/plugins/eof_context.py
@@ -39,7 +39,7 @@ class EndOfFileContextListener(sublime_plugin.EventListener):
         # NOTE: the whole selection must appear inside the last line for this
         # to match; a selection that is only partially in the last line is
         # not contained in the last line.
-        sels = [last_line.contains(s) for s in view.sel()]
+        sels = (last_line.contains(s) for s in view.sel())
 
         # Depending on match_all, indicate if one or all selections are on
         # the last line

--- a/plugins/eof_context.py
+++ b/plugins/eof_context.py
@@ -1,0 +1,49 @@
+import sublime
+import sublime_plugin
+
+# This is a simple example of implementing a custom key binding context using
+# an event listener listening for on_query_context.
+#
+# In this example we provide a custom key context named last_line which is a
+# boolean context that can tell you if one or all of the selections have
+# their cursor positioned in the last line of the file.
+#
+# This example key binding shows how to use this; the echo command will only
+# display output in the console if the cursor is in the last line of the file.
+#
+#    { "keys": ["ctrl+shift+h"], "command": "echo",
+#      "args": {"message": "This is the last line of the file"},
+#      "context": [
+#        { "key": "last_line", "operator": "equal", "operand": true },
+#      ],
+#    },
+
+
+class EndOfFileContextListener(sublime_plugin.EventListener):
+    """
+    Check if one or all selections have their cursor positioned in the last
+    line of the file.
+    """
+    def on_query_context(self, view, key, operator, operand, match_all):
+        # If this isn't the key context we know about, pass through to let
+        # Sublime ask another context.
+        if key != "last_line":
+            return None
+
+        # Get a region that represents the last line in the view, and the
+        # character offset that represents the end of the file.
+        last_line = view.line(len(view))
+
+        # Check to see which of the selections is contained in the last line.
+        #
+        # NOTE: the whole selection must appear inside the last line for this
+        # to match; a selection that is only partially in the last line is
+        # not contained in the last line.
+        sels = [last_line.contains(s) for s in view.sel()]
+
+        # Depending on match_all, indicate if one or all selections are on
+        # the last line
+        lhs = all(sels) if match_all else any(sels)
+
+        # Return if they're equal or not
+        return lhs == operand if operator == sublime.OP_EQUAL else lhs != operand

--- a/plugins/insert_to_column.py
+++ b/plugins/insert_to_column.py
@@ -1,0 +1,51 @@
+import sublime
+import sublime_plugin
+
+from bisect import bisect_left
+
+# This plugin was created for someone grumpy on the forum who never came back
+# to collect the answer, but this could be useful anyway.
+#
+# This implements an insert_to_column command that will insert whitespace at
+# every cursor that exists to move the cursor to the column specified. When
+# this is 0, the next closest ruler is used, with colunn 72 being a fallback
+# if there are no rulers that match.
+#
+# This could be used to add whitespace to the ends of lines, such as to align
+# comments or tables.
+
+class InsertToColumnCommand(sublime_plugin.TextCommand):
+    """
+    Insert spaces at every selection in order to move the cursor
+    to the given column, or the next ruler, or column 72.
+
+    Cursors that are already at or past the destination don't
+    move.
+
+    This requires all selections to be empty so that we don't
+    clobber any selected text.
+    """
+    def run(self, edit, col=0):
+        rulers = sorted(self.view.settings().get('rulers', []))
+
+        for sel in self.view.sel():
+            caret = self.view.rowcol(sel.a)[1]
+            col = col or self.find_next_ruler(caret, rulers)
+            spaces = col - caret
+            if spaces > 0:
+                self.view.insert(edit, sel.a, spaces * " ")
+
+    def find_next_ruler(self, caret, rulers):
+        if rulers:
+            pos = bisect_left(rulers, caret)
+            if pos == len(rulers) - 1:
+                return caret
+
+            return rulers[pos] if rulers[pos] != caret else rulers[pos + 1]
+
+        return 72
+
+    def is_enabled(self, col=0):
+        return all(s.empty() for s in self.view.sel())
+
+

--- a/plugins/insert_to_column.py
+++ b/plugins/insert_to_column.py
@@ -8,7 +8,7 @@ from bisect import bisect_left
 #
 # This implements an insert_to_column command that will insert whitespace at
 # every cursor that exists to move the cursor to the column specified. When
-# this is 0, the next closest ruler is used, with colunn 72 being a fallback
+# this is 0, the next closest ruler is used, with column 72 being a fallback
 # if there are no rulers that match.
 #
 # This could be used to add whitespace to the ends of lines, such as to align

--- a/plugins/local_font_size.py
+++ b/plugins/local_font_size.py
@@ -1,0 +1,59 @@
+import sublime
+import sublime_plugin
+
+
+# Related reading;
+#     https://forum.sublimetext.com/t/setting-different-font-sizes-for-different-tabs-files/15685?
+#
+# This plugin implements versions of the commands that increase, decrease and
+# reset the font size in Sublime, but here they apply only to the current file.
+# Using this you could have different font sizes in different tabs as desired.
+#
+# To use these commands, set up key bindings similar to the following:
+#
+# { "keys": ["alt+ctrl+="], "command": "increase_local_font_size" },
+# { "keys": ["alt+ctrl+-"], "command": "decrease_local_font_size" },
+# { "keys": ["alt+ctrl+0"], "command": "reset_local_font_size" },
+#
+# The toggle_setting_ex.py plugin also available in this repository provides
+# another way to do a similar action, in that case swapping between a set of
+# known font sizes.
+
+
+class IncreaseLocalFontSizeCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        current = self.view.settings().get("font_size", 10)
+
+        if current >= 36:
+            current += 4
+        elif current >= 24:
+            current += 2
+        else:
+            current += 1
+
+        if current > 128:
+            current = 128
+
+        self.view.settings().set("font_size", current)
+
+
+class DecreaseLocalFontSizeCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        current = self.view.settings().get("font_size", 10)
+
+        if current >= 40:
+            current -= 4
+        elif current >= 26:
+            current -= 2
+        else:
+            current -= 1
+
+        if current < 8:
+            current = 8
+
+        self.view.settings().set("font_size", current)
+
+
+class ResetLocalFontSizeCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        self.view.settings().erase("font_size")

--- a/plugins/pattern_navigate.py
+++ b/plugins/pattern_navigate.py
@@ -1,0 +1,55 @@
+import sublime
+import sublime_plugin
+
+# Related Reading:
+#     https://forum.sublimetext.com/t/find-for-a-macro/57387/
+#
+# This example command allows you to jump the cursor to the next or previous
+# location of a given pattern of text, which can be either a regex or not and
+# case sensitive or not based on command arguments.
+#
+# A use case for this is implementing a specific Find operation in a macro in
+# a repeatable way.
+
+
+class PatternNavigateCommand(sublime_plugin.TextCommand):
+    """
+    Jump the selection in the file to the next or previous location of the
+    given textual pattern based on the current cursor location. The search
+    direction is controlled by the forward argument, and will wrap around the
+    ends of the buffer.
+    """
+    def run(self, edit, pattern, literal=True, ignorecase=False, forward=True):
+        # Convert the incoming arguments to the appropriate search flags.
+        flags = ((sublime.LITERAL if literal else 0) |
+                 (sublime.IGNORECASE if ignorecase else 0))
+
+        # Find the locations where this pattern occurs; leave if none
+        regions = self.view.find_all(pattern, flags)
+        if not regions:
+            return
+
+        # Get a starting point for our search, and where we should jump to if
+        # there are no matches in the specified direction.
+        point = self.view.sel()[0].b
+        fallback = regions[-1] if not forward else regions[0]
+
+        # Remove all selections.
+        self.view.sel().clear()
+
+        # Look in the given direction for the first match from the current
+        # position; if one is found jump there.
+        pick = lambda p: (point < p.a) if forward else (point > p.a)
+        for pos in regions if forward else reversed(regions):
+            if pick(pos):
+                return self.jump(pos.a)
+
+        # No matches in the search direction, so wrap around.
+        self.jump(fallback.a)
+
+    def jump(self, point):
+        # Add in the given position as a selection and ensure that it's
+        # visible.
+        self.view.sel().add(sublime.Region(point))
+        self.view.show(point, True)
+

--- a/plugins/scope_navigate.py
+++ b/plugins/scope_navigate.py
@@ -1,0 +1,51 @@
+import sublime
+import sublime_plugin
+
+# Related Reading:
+#     https://forum.sublimetext.com/t/keybinding-to-find-a-particular-set-of-characters/49064
+#
+# This command allows you to easily jump the cursor to the next or previous
+# location of a specific "scope" in the file. This is a bit more advanced as a
+# navigation method, but would allow you to for example create a key binding
+# that always jumps between comments in files, even when switching languages.
+#
+# Use 'Tools > Developer > Show Scope Name' to determine the scope to use here.
+
+
+class ScopeNavigateCommand(sublime_plugin.TextCommand):
+    """
+    Jump the selection in the file to the next or previous location of the
+    given scope based on the current cursor location. The search direction is
+    controlled by the forward argument, and will wrap around the ends of the
+    buffer.
+    """
+    def run(self, edit, scope, forward=True):
+        # Find the locations where this scope occurs; leave if none
+        regions = self.view.find_by_selector(scope)
+        if not regions:
+            return
+
+        # Get a starting point for our search, and where we should jump to if
+        # there are no matches in the specified direction.
+        point = self.view.sel()[0].b
+        fallback = regions[-1] if not forward else regions[0]
+
+        # Remove all selections.
+        self.view.sel().clear()
+
+        # Look in the given direction for the first match from the current
+        # position; if one is found jump there.
+        pick = lambda p: (point < p.a) if forward else (point > p.a)
+        for pos in regions if forward else reversed(regions):
+            if pick(pos):
+                return self.jump(pos.a)
+
+        # No matches in the search direction, so wrap around.
+        self.jump(fallback.a)
+
+    def jump(self, point):
+        # Add in the given position as a selection and ensure that it's
+        # visible.
+        self.view.sel().add(sublime.Region(point))
+        self.view.show(point, True)
+

--- a/plugins/selection_to_top.py
+++ b/plugins/selection_to_top.py
@@ -1,0 +1,17 @@
+import sublime
+import sublime_plugin
+
+
+class SelectionToTopCommand(sublime_plugin.TextCommand):
+    """
+    Jump the viewport in the file so that the selection is at the top of the
+    file display area. Handy while conducting reviews.
+    """
+    def run(self, edit):
+        position = self.view.sel()[0]
+
+        offs = self.view.rowcol(position.begin())[0] * self.view.line_height()
+        self.view.set_viewport_position((0.0, offs), True)
+
+        self.view.sel().clear()
+        self.view.sel().add(position)

--- a/plugins/selectionless_scroll_lines.py
+++ b/plugins/selectionless_scroll_lines.py
@@ -1,0 +1,24 @@
+import sublime
+import sublime_plugin
+
+# This implements a selectionless_scroll_lines command that is a drop in
+# replacement for the scroll_lines command that is in the Sublime core; it
+# does the same thing but scrolls the view without changing the location of
+# the cursors as the built in command does.
+#
+# The following key bindings show how to use it (they overwrite the built in
+# key bindings on the built in command, blocking them from being used via the
+# keyboard).
+
+# { "keys": ["ctrl+up"], "command": "selectionless_scroll_lines", "args": {"amount": 1.0 } },
+# { "keys": ["ctrl+down"], "command": "selectionless_scroll_lines", "args": {"amount": -1.0 } },
+
+class SelectionlessScrollLinesCommand(sublime_plugin.TextCommand):
+    """
+    Scroll the view into the file up or down by the amount provided, leaving
+    the cursors in their current location.
+    """
+    def run(self, edit, amount=1.0):
+        height = self.view.line_height()
+        x,y = self.view.viewport_position()
+        self.view.set_viewport_position((x, y + (height * -amount)))

--- a/plugins/selectionless_scroll_lines.py
+++ b/plugins/selectionless_scroll_lines.py
@@ -4,10 +4,10 @@ import sublime_plugin
 # This implements a selectionless_scroll_lines command that is a drop in
 # replacement for the scroll_lines command that is in the Sublime core; it
 # does the same thing but scrolls the view without changing the location of
-# the cursors as the built in command does.
+# the cursors as the built-in command does.
 #
-# The following key bindings show how to use it (they overwrite the built in
-# key bindings on the built in command, blocking them from being used via the
+# The following key bindings show how to use it (they overwrite the built-in
+# key bindings on the built-in command, blocking them from being used via the
 # keyboard).
 
 # { "keys": ["ctrl+up"], "command": "selectionless_scroll_lines", "args": {"amount": 1.0 } },

--- a/plugins/snippets_with_selections.py
+++ b/plugins/snippets_with_selections.py
@@ -1,0 +1,25 @@
+import sublime
+import sublime_plugin
+
+# Related Reading:
+#     https://forum.sublimetext.com/t/parse-two-selected-lines-in-html-tags/56162
+
+# This plugin implementd a version of the insert_snippet command that provides
+# access to each individual selection as numbered variables, such as
+# SELECTION_1, SELECTION_2, and so on. This allows an expansion to include
+# multuple selections in the replacement.
+
+class InsertSnippetWithSelectionsCommand(sublime_plugin.TextCommand):
+    """
+    Since the normal "insert_snippet" command would insert contents in all
+    selections, this version "joins" all of the current selections into a
+    single selection first.
+    """
+    def run(self, edit, **kwargs):
+        sel = self.view.sel()
+        for idx in range(len(sel)):
+            kwargs["SELECTION_%d" % (idx + 1)] = self.view.substr(sel[idx])
+
+        self.view.sel().add(sublime.Region(sel[0].begin(), sel[-1].end()))
+        self.view.run_command("insert_snippet", kwargs)
+

--- a/plugins/snippets_with_selections.py
+++ b/plugins/snippets_with_selections.py
@@ -4,10 +4,10 @@ import sublime_plugin
 # Related Reading:
 #     https://forum.sublimetext.com/t/parse-two-selected-lines-in-html-tags/56162
 
-# This plugin implementd a version of the insert_snippet command that provides
+# This plugin implements a version of the insert_snippet command that provides
 # access to each individual selection as numbered variables, such as
 # SELECTION_1, SELECTION_2, and so on. This allows an expansion to include
-# multuple selections in the replacement.
+# multiple selections in the replacement.
 
 class InsertSnippetWithSelectionsCommand(sublime_plugin.TextCommand):
     """

--- a/plugins/update_last_edited.py
+++ b/plugins/update_last_edited.py
@@ -1,0 +1,47 @@
+import sublime
+import sublime_plugin
+import time
+
+# Related Reading:
+#     https://forum.sublimetext.com/t/automatically-updated-timestamp/7156
+#
+# This is a simple plugin for people that like to have a last edited timestamp
+# directly inside their files. It implements a command that will find such a
+# timestamp based on a header and then update it with the current time. The
+# header to look for and the date format are user customizable.
+#
+# The event listener will apply the command on every save, making this seamless
+# as an operation. If you would rather do this manually, remove or comment out
+# the event handler class and you can bind the command to a key instead.
+#
+# This example binding uses the chain command built into Sublime Text 4 to
+# execute first this command, then the save command.
+
+# { "keys": ["super+t"], "command": "chain",
+#    "args": {
+#       "commands": [
+#          {"command": "update_last_edited_date"},
+#          {"command": "save"},
+#       ]
+#    }
+# },
+
+class UpdateLastEditedDateCommand(sublime_plugin.TextCommand):
+    """
+    Check the current file for the first line that contains the provided
+    header, and if found update it to include the current date and time
+    as formatted by the given date format.
+    """
+    def run(self, edit, hdr="Last Edited: ", fmt="%d %b %Y %I:%M%p"):
+        span = self.view.find(f'{hdr}.*$', 0)
+        if span is not None:
+            self.view.replace(edit, span, f"{hdr}{time.strftime(fmt)}")
+
+
+class UpdateLastSavedEvent(sublime_plugin.EventListener):
+    """
+    Update the last edited time in a file every time it's saved.
+    """
+    def on_pre_save(self, view):
+        view.run_command('update_last_edited_date')
+

--- a/plugins/update_last_edited.py
+++ b/plugins/update_last_edited.py
@@ -32,10 +32,10 @@ class UpdateLastEditedDateCommand(sublime_plugin.TextCommand):
     header, and if found update it to include the current date and time
     as formatted by the given date format.
     """
-    def run(self, edit, hdr="Last Edited: ", fmt="%d %b %Y %I:%M%p"):
-        span = self.view.find(f'{hdr}.*$', 0)
+    def run(self, edit, header="Last Edited: ", format="%d %b %Y %I:%M%p"):
+        span = self.view.find(f'{header}.*$', 0)
         if span is not None:
-            self.view.replace(edit, span, f"{hdr}{time.strftime(fmt)}")
+            self.view.replace(edit, span, f"{header}{time.strftime(format)}")
 
 
 class UpdateLastSavedEvent(sublime_plugin.EventListener):

--- a/plugins/update_last_edited.py
+++ b/plugins/update_last_edited.py
@@ -1,5 +1,7 @@
 import sublime
 import sublime_plugin
+
+import re
 import time
 
 # Related Reading:
@@ -33,7 +35,7 @@ class UpdateLastEditedDateCommand(sublime_plugin.TextCommand):
     as formatted by the given date format.
     """
     def run(self, edit, header="Last Edited: ", format="%d %b %Y %I:%M%p"):
-        span = self.view.find(f'{header}.*$', 0)
+        span = self.view.find(f'{re.escape(header)}.*$', 0)
         if span is not None:
             self.view.replace(edit, span, f"{header}{time.strftime(format)}")
 

--- a/plugins/visible_multi_selection.py
+++ b/plugins/visible_multi_selection.py
@@ -7,7 +7,7 @@ import functools
 #     https://forum.sublimetext.com/t/difference-when-multiple-selection/58087
 #
 # This simple plugin makes it easier to visualize when there is more than one
-# cursor active in the current file (particuarly when one or more of them may
+# cursor active in the current file (particularly when one or more of them may
 # be outside the visible area of the file) by changing the state of the cursor.
 #
 # In this example the cursor is made wider when there is more than one, but

--- a/plugins/visible_multi_selection.py
+++ b/plugins/visible_multi_selection.py
@@ -1,0 +1,45 @@
+import sublime
+import sublime_plugin
+
+import functools
+
+# Related reading:
+#     https://forum.sublimetext.com/t/difference-when-multiple-selection/58087
+#
+# This simple plugin makes it easier to visualize when there is more than one
+# cursor active in the current file (particuarly when one or more of them may
+# be outside the visible area of the file) by changing the state of the cursor.
+#
+# In this example the cursor is made wider when there is more than one, but
+# this could be customized to use any number of settings.
+
+
+class GiantCursorEventListener(sublime_plugin.ViewEventListener):
+    pending = 0
+
+    def on_selection_modified_async(self):
+        self.pending += 1
+        sublime.set_timeout_async(functools.partial(self.update_cursor), 500)
+
+    def update_cursor(self):
+        self.pending -= 1
+        if self.pending != 0:
+            return
+
+        s = self.view.settings()
+
+        # Count of selections now and the last time we were triggered. If they
+        # are the same, leave.
+        now = len(self.view.sel())
+        then = s.get('_sel_count', -1)
+
+        if now == then:
+            return
+
+        # Remove the setting on 1 selection, otherwise increase it.
+        # Save this selection count, then erase or add the setting.
+        s.set('_sel_count', now)
+        if now == 1:
+            s.erase("caret_extra_width")
+        else:
+            s.set("caret_extra_width", 4)


### PR DESCRIPTION
This includes some new example plugins to the plugins folder, showing
off some more common questions and also providing some items that are
generally useful to people at large.

 * A command to clear the console
 * Inserting text up to a specific column (e.g. whitespace)
 * Key binding context example for knowing if the cursor is at the EOF
 * Expanding snippets with multiple versions of selected text at once
 * Changing the local font size of a tab
 * Scrolling the viewport without moving the cursor
 * Scrolling the viewport to put the selected text at the top of the tab
 * Navigate a file by scopes
 * Navigate a file by arbitrary regex
 * Update a header in a file whenever a file is saved
 * Change the cursor when there is more than one selection