### PR TITLE
Include an example plugin for a key context

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -191,3 +191,8 @@ of each file for more information on full usage.
    visibly detect when there is more than one active cursor in the current file
    by changing cursor settings (e.g. making the cursor wider) when there is more
    than one.
+
+ * [reversed_selection_listener.py](reversed_selection_listener.py) is a sample
+   of an event listener that illustrates how to listen for a custom key context
+   in order to make any custom key binding you like. This sample allows you to
+   set key bindings to only be active when the selection is "Reversed".

--- a/plugins/reversed_selection_listener.py
+++ b/plugins/reversed_selection_listener.py
@@ -18,6 +18,7 @@ import sublime_plugin
 #    ]
 # },
 
+
 class ReverseSelectionListener(sublime_plugin.EventListener):
     """
     This event listener listens for a key context named reversed_selection and
@@ -26,13 +27,27 @@ class ReverseSelectionListener(sublime_plugin.EventListener):
     to work across multiple cursors.
     """
     def on_query_context(self, view, key, operator, operand, match_all):
+        # If this is not the key that we understand, defer to another listener.
         if key != "reversed_selection":
             return None
 
-        lhs = operand
-        if match_all:
-            rhs = all([r.a > r.b for r in view.sel()])
-        else:
-            rhs = view.sel()[0].a > view.sel()[0].b
+        # If the operator is not equal, flip the state of the operand to make
+        # it match what OP_EQUAL would do.
+        if operator == sublime.OP_NOT_EQUAL:
+            operand = not operand
 
-        return True if operator == sublime.OP_EQUAL and rhs == lhs else False
+        # Test each selection for being either forward (operand == true) or
+        # backwards (operand == false), since that controls what we're testing
+        # for. The array must always contain True where the requested condition
+        # matches.
+        sels = ([r.a > r.b for r in view.sel()] if operand
+                       else [r.a < r.b for r in view.sel()])
+
+        # Either all values must be True, or just one, depending on the state
+        # of the given match_all argument.
+        criteria = all(sels) if match_all else any(sels)
+
+        # Criteria is now True when the condition matches the request and False
+        # when it does not. Our return is whether the actual result matches the
+        # desired outcome.
+        return criteria

--- a/plugins/reversed_selection_listener.py
+++ b/plugins/reversed_selection_listener.py
@@ -1,0 +1,38 @@
+import sublime
+import sublime_plugin
+
+# Related reading:
+#   https://discord.com/channels/280102180189634562/280102180189634562/958470369767997500
+#
+# This plugin provides a custom key binding context named reversed_selection
+# which can be used to create key bindings that trigger only when the selection
+# is "normal" (cursor on the right) or reversed (cursor on the left).
+#
+# An example of this in use is the following key binding, which will echo an
+# empty dictionary to the console if the key is pressed and all selections are
+# reversed.
+#
+# { "keys": ["ctrl+alt+c"], "command": "echo",
+#   "context": [
+#     { "key": "reversed_selection", "operator": "equal", "operand": true, "match_all": true, },
+#    ]
+# },
+
+class ReverseSelectionListener(sublime_plugin.EventListener):
+    """
+    This event listener listens for a key context named reversed_selection and
+    will return True or False depending on whether the selection is selected in
+    a reverse manner or not. match_all is also supported, to allow the context
+    to work across multiple cursors.
+    """
+    def on_query_context(self, view, key, operator, operand, match_all):
+        if key != "reversed_selection":
+            return None
+
+        lhs = operand
+        if match_all:
+            rhs = all([r.a > r.b for r in view.sel()])
+        else:
+            rhs = view.sel()[0].a > view.sel()[0].b
+
+        return True if operator == sublime.OP_EQUAL and rhs == lhs else False


### PR DESCRIPTION
This is a simple plugin that was created in response to a request from
Troels on the Sublime Text Discord; it implements a custom key binding
context that allows you to detect if the selection(s) are reversed or
not.